### PR TITLE
Handle Material I/O for Production = Consumption

### DIFF
--- a/src/features/planning/calculations/buildingCalculations.ts
+++ b/src/features/planning/calculations/buildingCalculations.ts
@@ -34,6 +34,11 @@ export function useBuildingCalculation() {
 
 			// iterate over active_recipes
 			building.activeRecipes.forEach((ar) => {
+				// skip if the recipes amount is set to 0
+				if (ar.amount === 0) {
+					return;
+				}
+
 				// handle inputs
 				ar.recipe.Inputs.forEach((arInput) => {
 					buildingMaterialIOInput = combineMaterialIOMinimal([

--- a/src/features/planning/util/materialIO.util.ts
+++ b/src/features/planning/util/materialIO.util.ts
@@ -113,11 +113,21 @@ export function useMaterialIOUtil() {
 					price: element.price,
 				};
 
-				element.delta < 0
-					? combinedMap[element.ticker].inputPlanets.push(planetPart)
-					: combinedMap[element.ticker].outputPlanets.push(
-							planetPart
-						);
+				/*
+				 * Delta check, handle delta === 0 separately, as the planet is
+				 * full consuming all its producing, so it needs to be on both sides
+				 */
+				if (element.delta < 0) {
+					// only consuming
+					combinedMap[element.ticker].inputPlanets.push(planetPart);
+				} else if (element.delta > 0) {
+					// only producing
+					combinedMap[element.ticker].outputPlanets.push(planetPart);
+				} else if (element.delta === 0) {
+					// full consuming all its producing
+					combinedMap[element.ticker].inputPlanets.push(planetPart);
+					combinedMap[element.ticker].outputPlanets.push(planetPart);
+				}
 			});
 		});
 
@@ -148,7 +158,10 @@ export function useMaterialIOUtil() {
 				0
 			);
 
-			const weightedPrice: number = sumProduct / sumValue;
+			// check for NaN, as sumValue could be 0 and lead to zero-division
+			const weightedPrice: number = isNaN(sumProduct / sumValue)
+				? 0
+				: sumProduct / sumValue;
 
 			// update price
 			combinedMap[ticker].deltaPrice =

--- a/src/tests/features/planning/calculations/bonusCalculations.test.ts
+++ b/src/tests/features/planning/calculations/bonusCalculations.test.ts
@@ -202,11 +202,12 @@ describe("Planning: Bonus Calculations ", async () => {
 		test.each(workforceCases)(
 			"Efficiency: $expected",
 			async ({ building, workforce, expected }) => {
-				const { calculateBuildingWorkforceEfficiency } = useBonusCalculation();
+				const { calculateBuildingWorkforceEfficiency } =
+					useBonusCalculation();
 
-				expect(calculateBuildingWorkforceEfficiency(building, workforce)).toBe(
-					expected
-				);
+				expect(
+					calculateBuildingWorkforceEfficiency(building, workforce)
+				).toBe(expected);
 			}
 		);
 	});
@@ -218,15 +219,15 @@ describe("Planning: Bonus Calculations ", async () => {
 				const { calculateBuildingFactionBonus } = useBonusCalculation();
 
 				if (typeof expected === "object") {
-					// @ts-ignore test data mocking
-					expect(calculateBuildingFactionBonus(building, empire)).toStrictEqual(
-						expected
-					);
+					expect(
+						// @ts-ignore test data mocking
+						calculateBuildingFactionBonus(building, empire)
+					).toStrictEqual(expected);
 				} else {
-					// @ts-ignore test data mocking
-					expect(calculateBuildingFactionBonus(building, empire)).toBe(
-						expected
-					);
+					expect(
+						// @ts-ignore test data mocking
+						calculateBuildingFactionBonus(building, empire)
+					).toBe(expected);
 				}
 			}
 		);
@@ -433,6 +434,118 @@ describe("Planning: Bonus Calculations ", async () => {
 					{
 						efficiencyType: "FERTILITY",
 						value: 1.2575757575757576,
+					},
+					{
+						efficiencyType: "HQ",
+						value: 1.1,
+					},
+					{
+						efficiencyType: "EXPERT",
+						value: 1.1248,
+					},
+					{
+						efficiencyType: "COGC",
+						value: 1.1,
+					},
+					{
+						efficiencyType: "WORKFORCE",
+						value: 1.3138888888888889,
+					},
+					{
+						efficiencyType: "FACTION",
+						value: 1.0438095238095237,
+					},
+				],
+			});
+		});
+		it("Calculate all Efficiency factors and total, workforce COGC", async () => {
+			const { calculateBuildingEfficiency } = useBonusCalculation();
+
+			const testBuilding = {
+				Ticker: "FRM",
+				Pioneers: 20,
+				Settlers: 50,
+				Technicians: 10,
+				Engineers: 5,
+				Scientists: 5,
+				Expertise: "METALLURGY",
+			};
+			const testPlanet = { Fertility: -1.0 };
+			const testCorpHQ = true;
+			const testCOGC = "SETTLERS";
+			const testWorkforce = {
+				pioneer: {
+					name: "pioneer",
+					required: 100,
+					capacity: 100,
+					left: 0,
+					lux1: true,
+					lux2: true,
+					efficiency: 1.25,
+				},
+				settler: {
+					name: "settler",
+					required: 100,
+					capacity: 100,
+					left: 0,
+					lux1: true,
+					lux2: true,
+					efficiency: 1.625,
+				},
+				technician: {
+					name: "technician",
+					required: 100,
+					capacity: 150,
+					left: 50,
+					lux1: true,
+					lux2: false,
+					efficiency: 0.4,
+				},
+				engineer: {
+					name: "engineer",
+					required: 100,
+					capacity: 150,
+					left: 50,
+					lux1: true,
+					lux2: false,
+					efficiency: 0.1,
+				},
+				scientist: {
+					name: "scientist",
+					required: 100,
+					capacity: 150,
+					left: 50,
+					lux1: true,
+					lux2: false,
+					efficiency: 1.5,
+				},
+			};
+			const testExpert = {
+				Metallurgy: { name: "Metallurgy", amount: 3, bonus: 0.1248 },
+			};
+			const testEmpire = {
+				faction: "MORIA",
+				permits_used: 20,
+				permits_total: 21,
+			};
+
+			const result = calculateBuildingEfficiency(
+				// @ts-expect-error mock test data
+				testBuilding,
+				testPlanet,
+				testCorpHQ,
+				testCOGC,
+				testWorkforce,
+				testExpert,
+				testEmpire
+			);
+
+			expect(result).toStrictEqual({
+				totalEfficiency: 0,
+				elements: [
+					{
+						efficiencyType: "FERTILITY",
+						value: 0,
 					},
 					{
 						efficiencyType: "HQ",

--- a/src/tests/features/planning/calculations/buildingCalculations.test.ts
+++ b/src/tests/features/planning/calculations/buildingCalculations.test.ts
@@ -83,5 +83,63 @@ describe("Planning: Workforce Calculations", async () => {
 				},
 			]);
 		});
+
+		it("Skip recipes which amount = 0", async () => {
+			const { calculateMaterialIO } = useBuildingCalculation();
+
+			const fakeData = [
+				{
+					amount: 1,
+					totalBatchTime: 17280000 + 51840000,
+					activeRecipes: [
+						{
+							recipeId: "foo",
+							amount: 0,
+							time: 17280000,
+							recipe: {
+								Inputs: [
+									{ Ticker: "DW", Amount: 20 },
+									{ Ticker: "EPO", Amount: 5 },
+								],
+								Outputs: [{ Ticker: "O", Amount: 3 }],
+							},
+						},
+						{
+							recipeId: "moo",
+							amount: 1,
+							time: 51840000,
+							recipe: {
+								Inputs: [
+									{ Ticker: "MG", Amount: 3 },
+									{ Ticker: "O", Amount: 1 },
+								],
+								Outputs: [{ Ticker: "NR", Amount: 3 }],
+							},
+						},
+					],
+				},
+			];
+
+			// @ts-expect-error mocked data
+			const result = calculateMaterialIO(fakeData);
+
+			expect(result).toStrictEqual([
+				{
+					input: 3.75,
+					output: 0,
+					ticker: "MG",
+				},
+				{
+					input: 1.25,
+					output: 0,
+					ticker: "O",
+				},
+				{
+					input: 0,
+					output: 3.75,
+					ticker: "NR",
+				},
+			]);
+		});
 	});
 });

--- a/src/tests/features/planning/util/materialIO.util.test.ts
+++ b/src/tests/features/planning/util/materialIO.util.test.ts
@@ -119,8 +119,12 @@ describe("Util: materialIO ", async () => {
 		expect(findWater?.delta).toBe(5);
 
 		// individual weight
-		expect(findC?.individualVolume).toBe(gameDataStore.materials["C"].Volume);
-		expect(findC?.individualWeight).toBe(gameDataStore.materials["C"].Weight);
+		expect(findC?.individualVolume).toBe(
+			gameDataStore.materials["C"].Volume
+		);
+		expect(findC?.individualWeight).toBe(
+			gameDataStore.materials["C"].Weight
+		);
 
 		// total
 		expect(findWater?.totalVolume).toBe(
@@ -154,8 +158,12 @@ describe("Util: materialIO ", async () => {
 			[{ ticker: "OVE", delta: -1 }]
 		);
 
-		expect(resultSell).toStrictEqual([{ ticker: "OVE", delta: 1, price: 10 }]);
-		expect(resultBuy).toStrictEqual([{ ticker: "OVE", delta: -1, price: -10 }]);
+		expect(resultSell).toStrictEqual([
+			{ ticker: "OVE", delta: 1, price: 10 },
+		]);
+		expect(resultBuy).toStrictEqual([
+			{ ticker: "OVE", delta: -1, price: -10 },
+		]);
 	});
 
 	it("combineEmpireMaterialIO", async () => {
@@ -224,5 +232,41 @@ describe("Util: materialIO ", async () => {
 		expect(result[0].output).toBe(3);
 		expect(result[0].inputPlanets.length).toBe(2);
 		expect(result[0].outputPlanets.length).toBe(0);
+	});
+	it("combineEmpireMaterialIO", async () => {
+		const fakeInput: IEmpirePlanMaterialIO[] = [
+			{
+				planetId: "foo",
+				planUuid: "foo#1",
+				planName: "foo",
+				materialIO: [
+					{
+						ticker: "RAT",
+						input: 10,
+						output: 10,
+						delta: 0,
+						individualVolume: 0,
+						individualWeight: 0,
+						totalWeight: 0,
+						totalVolume: 0,
+						price: 5,
+					},
+				],
+			},
+		];
+
+		const { combineEmpireMaterialIO } = useMaterialIOUtil();
+
+		const result = combineEmpireMaterialIO(fakeInput);
+
+		expect(result.length).toBe(1);
+
+		expect(result[0].ticker).toBe("RAT");
+		expect(result[0].delta).toBe(0);
+		expect(result[0].deltaPrice).toBe(0);
+		expect(result[0].input).toBe(10);
+		expect(result[0].output).toBe(10);
+		expect(result[0].inputPlanets.length).toBe(1);
+		expect(result[0].outputPlanets.length).toBe(1);
 	});
 });


### PR DESCRIPTION
Handles zero-division case on empire material i/o, adds plans that consume everything they consume to production AND consumption planet list, skip building recipes that have their amount set to 0 in plans.

Add tests, improve tests

close #56