### PR TITLE
Update markdown import options in HelpDrawer.vue

### DIFF
--- a/src/features/help/components/HelpDrawer.vue
+++ b/src/features/help/components/HelpDrawer.vue
@@ -6,10 +6,12 @@
 
 	const showDrawer: Ref<boolean> = ref(false);
 
-	async function loadMarkdown() {
+	async function loadMarkdown(): Promise<string> {
 		const markdownFiles = import.meta.glob("@/assets/help/*.md", {
-			as: "raw",
-		});
+			query: "?raw",
+			import: "default",
+		}) as Record<string, () => Promise<string>>;
+
 		const path = `/src/assets/help/${props.fileName}.md`;
 		const loader = markdownFiles[path];
 		if (!loader)


### PR DESCRIPTION
Changed the import.meta.glob options for loading markdown files to use 'query: ?raw' and 'import: default' for improved compatibility. Also updated the loadMarkdown function to explicitly return a Promise<string>. close #73