### PR TITLE
fix(planning): roi and recipe revenue calculations fixed

### DIFF
--- a/src/features/game_data/useExchangeData.ts
+++ b/src/features/game_data/useExchangeData.ts
@@ -63,10 +63,17 @@ export function useExchangeData() {
 			overview.Ask[type] = ticker.Ask ?? 0;
 			overview.Bid[type] = ticker.Bid ?? 0;
 			overview.Average[type] = ticker.PriceAverage;
-			overview.PP7D[type] = ticker.PriceAverage;
-			overview.PP30D[type] = ticker.PriceAverage;
 			overview.Supply[type] = ticker.Supply ?? 0;
 			overview.Demand[type] = ticker.Demand ?? 0;
+
+			const d7ticker = getExchangeTicker(
+				`${materialTicker}.PP7D_${type}`
+			);
+			const d30ticker = getExchangeTicker(
+				`${materialTicker}.PP30D_${type}`
+			);
+			overview.PP7D[type] = d7ticker.PriceAverage;
+			overview.PP30D[type] = d30ticker.PriceAverage;
 		});
 
 		return overview;

--- a/src/features/planning/calculations/buildingCalculations.ts
+++ b/src/features/planning/calculations/buildingCalculations.ts
@@ -7,7 +7,7 @@ import {
 	IProductionBuilding,
 } from "@/features/planning/usePlanCalculation.types";
 
-const TOTALMSDAY: number = 24 * 60 * 60 * 1000;
+export const TOTALMSDAY: number = 24 * 60 * 60 * 1000;
 
 export function useBuildingCalculation() {
 	const { combineMaterialIOMinimal } = useMaterialIOUtil();

--- a/src/features/planning/usePlanCalculation.ts
+++ b/src/features/planning/usePlanCalculation.ts
@@ -5,7 +5,10 @@ import { useGameDataStore } from "@/stores/gameDataStore";
 
 // Composables
 import { useBuildingData } from "@/features/game_data/useBuildingData";
-import { useBuildingCalculation } from "@/features/planning/calculations/buildingCalculations";
+import {
+	TOTALMSDAY,
+	useBuildingCalculation,
+} from "@/features/planning/calculations/buildingCalculations";
 import { useMaterialIOUtil } from "@/features/planning/util/materialIO.util";
 import { usePrice } from "@/features/cx/usePrice";
 
@@ -430,16 +433,18 @@ export function usePlanCalculation(
 						"SELL"
 					);
 					// input cost
-					const dailyCost: number = getMaterialIOTotalPrice(
-						br.Inputs.map((i) => {
-							return {
-								ticker: i.Ticker,
-								output: 0,
-								input: i.Amount,
-							};
-						}),
-						"SELL"
-					);
+					const dailyCost: number =
+						-1 *
+						getMaterialIOTotalPrice(
+							br.Inputs.map((i) => {
+								return {
+									ticker: i.Ticker,
+									output: 0,
+									input: i.Amount,
+								};
+							}),
+							"BUY"
+						);
 
 					/**
 					 * Daily Revenue of a recipe option:
@@ -450,9 +455,11 @@ export function usePlanCalculation(
 					 * 	- Building Daily Workforce Cost (lux1 + lux2)
 					 */
 
+					const maxDailyRuns: number = TOTALMSDAY / br.TimeMs;
+
 					const dailyRevenue: number =
-						dailyIncome -
-						dailyCost -
+						dailyIncome * maxDailyRuns -
+						dailyCost * maxDailyRuns -
 						constructionCost * -1 * (1 / 180) -
 						-1 * workforceDailyCost;
 


### PR DESCRIPTION
Plan recipe calculations were not respecting the number of daily runs of this recipe for input cost and output revenue, cost was on "SELL" cx search. Also fixed material tiles exchange overview for PP7D and PP30D exchange specifics.

fix #84