### PR TITLE
feat(exchange): implements exchange management

### DIFF
--- a/src/assets/css/style.css
+++ b/src/assets/css/style.css
@@ -49,7 +49,7 @@ html {
 }
 
 #markdown ul {
-	@apply space-y-1  pl-5 list-disc list-outside;
+	@apply space-y-1 pl-5 pb-3 list-disc list-outside;
 }
 
 #markdown table {

--- a/src/assets/help/exchanges.md
+++ b/src/assets/help/exchanges.md
@@ -1,0 +1,23 @@
+# Priorities
+
+The CX & Pricing Preferences to identify the price used for calculations are checked in the following order:
+
+- Planet Material-based
+- Empire Material-based
+- Planet CX-based
+- Empire CX-based
+- Fallback: PP30 Day Universe Price
+
+# Types
+
+Preferences can be set with the types **BUY**, **SELL** or **BOTH** and will be used for either consumed, produced or both types.
+
+If only a specific type is set, but the materials price should be calculated for another, higher preferences will supersede of fall back to 0 if none is available.
+
+# Examples
+
+1: The price for LST should be used. You have no Material-based setting for Limestone defined. Therefore the Planets CX preference is applied. If no such preference exists, the Empire CX preference is used. As you have both a Planet and Empire CX preference defined the Planet CX preference will supersede your Empire CX preference.
+
+2: The price for NS should be used. You have an Material-based setting for NS on the Empire level, additionally you've set your preference Material-based on the Planet that should be calculated. The Planet Material-based preference for NS will supersede your Empire Material-based definition. As there is a Material-based definition available no CX-based preference will be applied.
+
+3: The price for BBH should be used. You have not set any Material-based or CX-based preferences. The price for BBH therefore is calculated with 0.

--- a/src/features/api/cxData.api.ts
+++ b/src/features/api/cxData.api.ts
@@ -16,7 +16,7 @@ import {
 } from "@/features/api/schemas/cxData.schemas";
 
 // Types & Interfaces
-import { ICX } from "@/stores/planningStore.types";
+import { ICX, ICXData } from "@/stores/planningStore.types";
 import { ICXEmpireJunction } from "@/features/manage/manage.types";
 
 /**
@@ -88,5 +88,27 @@ export async function callUpdateCXJunctions(
 		junctions,
 		CXEmpireJunctionSchemaPayload,
 		CXListPayloadSchema
+	);
+}
+
+/**
+ * Patches an existing CX with new data
+ * @author jplacht
+ *
+ * @export
+ * @async
+ * @param {string} cxUuid CX Uuid
+ * @param {ICXData} data CX Preference Data
+ * @returns {Promise<ICXData>} Updated CX Preference Data
+ */
+export async function callPatchCX(
+	cxUuid: string,
+	data: ICXData
+): Promise<ICXData> {
+	return apiService.patch<CXDataSchemaType, CXDataSchemaType>(
+		`/cx/${cxUuid}`,
+		data,
+		CXDataSchema,
+		CXDataSchema
 	);
 }

--- a/src/features/exchanges/components/CXExchangePreference.vue
+++ b/src/features/exchanges/components/CXExchangePreference.vue
@@ -1,0 +1,113 @@
+<script setup lang="ts">
+	import { computed, PropType, ref, Ref } from "vue";
+
+	// Composables
+	import { useCXManagement } from "@/features/exchanges/useManageCX";
+
+	// Types & Interfaces
+	import { ICXDataExchangeOption } from "@/stores/planningStore.types";
+	import { ExchangeType, PreferenceType } from "../manageCX.types";
+
+	// UI
+	import { NSelect, NButton, NTable, NTag } from "naive-ui";
+	import { PlusSharp, ClearSharp } from "@vicons/material";
+
+	const props = defineProps({
+		cxOptions: {
+			type: Array as PropType<ICXDataExchangeOption[]>,
+			required: true,
+		},
+	});
+
+	const emit = defineEmits<{
+		(e: "update:cxOptions", value: ICXDataExchangeOption[]): void;
+	}>();
+
+	const localCXOptions = computed({
+		get: () => props.cxOptions,
+		set: (val: ICXDataExchangeOption[]) => emit("update:cxOptions", val),
+	});
+
+	const {
+		typeOptions,
+		exchangeOptions,
+		canAddExchangePreference,
+		updateExchangePreference,
+		deleteExchangePreference,
+	} = useCXManagement();
+
+	const selectedType: Ref<PreferenceType> = ref("BOTH");
+	const selectedExchange: Ref<ExchangeType> = ref("PP30D_UNIVERSE");
+</script>
+
+<template>
+	<div class="flex flex-row gap-x-1">
+		<div class="!min-w-[100px]">
+			<n-select
+				v-model:value="selectedType"
+				:options="typeOptions"
+				size="small"
+				placeholder="Preference Type"
+				class="w-full" />
+		</div>
+		<n-select
+			v-model:value="selectedExchange"
+			:options="exchangeOptions"
+			size="small"
+			placeholder="Exchange" />
+		<n-button
+			size="small"
+			:disabled="
+				!canAddExchangePreference(localCXOptions, selectedType).value
+			"
+			@click="
+				localCXOptions = updateExchangePreference(
+					localCXOptions,
+					selectedType,
+					selectedExchange
+				)
+			">
+			<template #icon><PlusSharp /></template>
+		</n-button>
+	</div>
+	<div class="pt-3">
+		<n-table striped>
+			<tr
+				v-for="preference in localCXOptions"
+				:key="`${preference.type}#${preference.exchange}`">
+				<td class="w-[75px]">
+					<n-tag
+						size="small"
+						:type="
+							preference.type === 'BUY'
+								? 'success'
+								: preference.type === 'SELL'
+								? 'error'
+								: 'info'
+						">
+						{{ preference.type }}
+					</n-tag>
+				</td>
+				<td>{{ preference.exchange }}</td>
+				<td class="text-right">
+					<n-button
+						size="tiny"
+						type="error"
+						@click="
+							localCXOptions = deleteExchangePreference(
+								localCXOptions,
+								preference.type
+							)
+						">
+						<template #icon><ClearSharp /></template>
+					</n-button>
+				</td>
+			</tr>
+			<tr
+				v-if="localCXOptions.length === 0"
+				class="text-center child:!text-white/50">
+				<td colspan="3">No Exchange Preference Configured</td>
+			</tr>
+		</n-table>
+	</div>
+</template>

--- a/src/features/exchanges/components/CXPlanetPreferenceTable.vue
+++ b/src/features/exchanges/components/CXPlanetPreferenceTable.vue
@@ -1,0 +1,138 @@
+<script setup lang="ts">
+	import { PropType, ref, Ref, watch } from "vue";
+
+	// Composables
+	import { usePlanetData } from "@/features/game_data/usePlanetData";
+
+	// Utils
+	import { formatNumber } from "@/util/numbers";
+
+	// Components
+	import CXExchangePreference from "@/features/exchanges/components/CXExchangePreference.vue";
+	import CXTickerPreference from "@/features/exchanges/components/CXTickerPreference.vue";
+	import MaterialTile from "@/features/material_tile/components/MaterialTile.vue";
+
+	// Types & Interfaces
+	import { ICXPlanetMap } from "../manageCX.types";
+
+	// UI
+	import { NButton, NTag } from "naive-ui";
+	import { XNDataTable, XNDataTableColumn } from "@skit/x.naive-ui";
+	import { EditSharp } from "@vicons/material";
+
+	const { getPlanetName } = usePlanetData();
+
+	const props = defineProps({
+		planetMap: {
+			type: Object as PropType<ICXPlanetMap>,
+			required: true,
+		},
+	});
+
+	const localMap: Ref<ICXPlanetMap> = ref(props.planetMap);
+
+	watch(
+		() => props.planetMap,
+		(newMap: ICXPlanetMap) => {
+			localMap.value = newMap;
+		}
+	);
+
+	const selectedPlanet: Ref<string | null> = ref(null);
+</script>
+
+<template>
+	<h2 class="text-xl font-bold my-auto pb-3">
+		Planet Preferences<span v-if="selectedPlanet"
+			>: {{ getPlanetName(selectedPlanet) }}
+		</span>
+	</h2>
+	<div
+		v-if="selectedPlanet"
+		class="grid grid-cols-1 xl:grid-cols-[40%_auto] gap-3 pb-3">
+		<div>
+			<h3 class="text-lg font-bold pb-3">Exchange</h3>
+			<CXExchangePreference
+				:key="`Exchanges#${selectedPlanet}`"
+				v-model:cx-options="localMap[selectedPlanet].exchanges" />
+		</div>
+		<div>
+			<h3 class="text-lg font-bold pb-3">Ticker</h3>
+			<CXTickerPreference
+				:key="`Ticker#${selectedPlanet}`"
+				v-model:cx-options="localMap[selectedPlanet].ticker" />
+		</div>
+	</div>
+	<XNDataTable :data="Object.values(localMap)" striped>
+		<XNDataTableColumn key="buttons" title="" width="50">
+			<template #render-cell="{ rowData }">
+				<n-button
+					size="tiny"
+					:type="
+						selectedPlanet === rowData.planet
+							? 'success'
+							: 'default'
+					"
+					@click="
+						selectedPlanet === rowData.planet
+							? (selectedPlanet = null)
+							: (selectedPlanet = rowData.planet)
+					">
+					<template #icon><EditSharp /></template>
+				</n-button>
+			</template>
+		</XNDataTableColumn>
+		<XNDataTableColumn key="planet" title="Planet" sorter="default">
+			<template #render-cell="{ rowData }">
+				{{ getPlanetName(rowData.planet) }}
+			</template>
+		</XNDataTableColumn>
+		<XNDataTableColumn key="exchanges" title="Exchanges" max-width="20%">
+			<template #render-cell="{ rowData }">
+				<div class="flex flex-col gap-y-1">
+					<div
+						v-for="exchange in rowData.exchanges"
+						:key="`${rowData.planet}#${exchange.type}#${exchange.exchange}`">
+						<n-tag
+							size="small"
+							:type="
+								exchange.type === 'BUY'
+									? 'success'
+									: exchange.type === 'SELL'
+									? 'error'
+									: 'info'
+							">
+							{{ exchange.type }}:
+							<strong>{{ exchange.exchange }}</strong>
+						</n-tag>
+					</div>
+				</div>
+			</template>
+		</XNDataTableColumn>
+		<XNDataTableColumn key="ticker" title="Ticker" max-width="50%">
+			<template #render-cell="{ rowData }">
+				<div class="flex flex-wrap gap-3">
+					<div
+						v-for="ticker in rowData.ticker"
+						:key="`${rowData.planet}#${ticker.type}#${ticker.value}`"
+						class="flex flex-row gap-x-1">
+						<MaterialTile :ticker="ticker.ticker" />
+						<n-tag
+							size="small"
+							:type="
+								ticker.type === 'BUY'
+									? 'success'
+									: ticker.type === 'SELL'
+									? 'error'
+									: 'info'
+							">
+							{{ ticker.type }}:
+							<strong>{{ formatNumber(ticker.value) }}</strong>
+							<span class="pl-1 font-light opacity-50">$</span>
+						</n-tag>
+					</div>
+				</div>
+			</template>
+		</XNDataTableColumn>
+	</XNDataTable>
+</template>

--- a/src/features/exchanges/components/CXTickerPreference.vue
+++ b/src/features/exchanges/components/CXTickerPreference.vue
@@ -1,0 +1,145 @@
+<script setup lang="ts">
+	import { computed, ComputedRef, PropType, ref, Ref } from "vue";
+
+	// Composables
+	import { useCXManagement } from "@/features/exchanges/useManageCX";
+
+	// Components
+	import MaterialTile from "@/features/material_tile/components/MaterialTile.vue";
+
+	// Types & Interfaces
+	import { ICXDataTickerOption } from "@/stores/planningStore.types";
+	import { PreferenceType } from "../manageCX.types";
+
+	// UI
+	import { NSelect, NButton, NInputNumber, NTable, NTag } from "naive-ui";
+	import { PlusSharp, ClearSharp } from "@vicons/material";
+	import { formatNumber } from "@/util/numbers";
+
+	const props = defineProps({
+		cxOptions: {
+			type: Array as PropType<ICXDataTickerOption[]>,
+			required: true,
+		},
+	});
+
+	const emit = defineEmits<{
+		(e: "update:cxOptions", value: ICXDataTickerOption[]): void;
+	}>();
+
+	const localCXOptions = computed({
+		get: () => props.cxOptions,
+		set: (val: ICXDataTickerOption[]) => emit("update:cxOptions", val),
+	});
+
+	const {
+		typeOptions,
+		materialOptions,
+		canAddTickerPreference,
+		deleteTickerPreference,
+		updateTickerPreference,
+	} = useCXManagement();
+
+	const sortedCXOptions: ComputedRef<ICXDataTickerOption[]> = computed(() => {
+		return [...localCXOptions.value].sort((a, b) =>
+			a.ticker > b.ticker ? 1 : -1
+		);
+	});
+
+	const selectedType: Ref<PreferenceType> = ref("BOTH");
+	const selectedTicker: Ref<string> = ref("DW");
+	const selectedValue: Ref<number> = ref(0);
+</script>
+
+<template>
+	<div class="flex flex-row gap-x-1">
+		<div class="!max-w-[100px]">
+			<n-select
+				v-model:value="selectedType"
+				:options="typeOptions"
+				size="small"
+				placeholder="Preference Type" />
+		</div>
+		<n-select
+			v-model:value="selectedTicker"
+			:options="materialOptions"
+			filterable
+			size="small"
+			placeholder="Material" />
+		<n-input-number
+			v-model:value="selectedValue"
+			:min="0"
+			:precision="2"
+			:show-button="false"
+			size="small"
+			class="!w-[300px]" />
+		<n-button
+			size="small"
+			:disabled="
+				!canAddTickerPreference(
+					localCXOptions,
+					selectedTicker,
+					selectedType
+				).value
+			"
+			@click="
+				localCXOptions = updateTickerPreference(
+					localCXOptions,
+					selectedTicker,
+					selectedType,
+					selectedValue
+				)
+			">
+			<template #icon><PlusSharp /></template>
+		</n-button>
+	</div>
+	<div class="pt-3">
+		<n-table striped>
+			<tr
+				v-for="preference in sortedCXOptions"
+				:key="`${preference.type}#${preference.ticker}`">
+				<td class="w-[75px]">
+					<n-tag
+						size="small"
+						:type="
+							preference.type === 'BUY'
+								? 'success'
+								: preference.type === 'SELL'
+								? 'error'
+								: 'info'
+						">
+						{{ preference.type }}
+					</n-tag>
+				</td>
+				<td>
+					<MaterialTile
+						:key="`${preference.ticker}#${preference.type}`"
+						:ticker="preference.ticker" />
+				</td>
+				<td class="text-right">
+					{{ formatNumber(preference.value) }}
+					<span class="pl-1 font-light text-white/50">$</span>
+				</td>
+				<td class="text-right">
+					<n-button
+						size="tiny"
+						type="error"
+						@click="
+							localCXOptions = deleteTickerPreference(
+								localCXOptions,
+								preference.ticker,
+								preference.type
+							)
+						">
+						<template #icon><ClearSharp /></template>
+					</n-button>
+				</td>
+			</tr>
+			<tr
+				v-if="localCXOptions.length === 0"
+				class="text-center child:!text-white/50">
+				<td colspan="4">No Ticker Preferences Configured</td>
+			</tr>
+		</n-table>
+	</div>
+</template>

--- a/src/features/exchanges/manageCX.types.ts
+++ b/src/features/exchanges/manageCX.types.ts
@@ -1,0 +1,48 @@
+import {
+	ICXDataExchangeOption,
+	ICXDataTickerOption,
+} from "@/stores/planningStore.types";
+
+export type PreferenceType = "BOTH" | "BUY" | "SELL";
+
+export type ExchangeType =
+	| "AI1_BUY"
+	| "AI1_SELL"
+	| "AI1_AVG"
+	| "IC1_BUY"
+	| "IC1_SELL"
+	| "IC1_AVG"
+	| "CI1_BUY"
+	| "CI1_SELL"
+	| "CI1_AVG"
+	| "CI2_BUY"
+	| "CI2_SELL"
+	| "CI2_AVG"
+	| "NC1_BUY"
+	| "NC1_SELL"
+	| "NC1_AVG"
+	| "NC2_BUY"
+	| "NC2_SELL"
+	| "NC2_AVG"
+	| "PP7D_AI1"
+	| "PP7D_IC1"
+	| "PP7D_CI1"
+	| "PP7D_CI2"
+	| "PP7D_NC1"
+	| "PP7D_NC2"
+	| "PP30D_AI1"
+	| "PP30D_IC1"
+	| "PP30D_CI1"
+	| "PP30D_CI2"
+	| "PP30D_NC1"
+	| "PP30D_NC2"
+	| "PP7D_UNIVERSE"
+	| "PP30D_UNIVERSE";
+
+export type ICXPlanetMapItem = {
+	planet: string;
+	exchanges: ICXDataExchangeOption[];
+	ticker: ICXDataTickerOption[];
+};
+
+export type ICXPlanetMap = Record<string, ICXPlanetMapItem>;

--- a/src/features/exchanges/useManageCX.ts
+++ b/src/features/exchanges/useManageCX.ts
@@ -1,0 +1,243 @@
+import { computed, ComputedRef } from "vue";
+
+// Stores
+import { useGameDataStore } from "@/stores/gameDataStore";
+
+// Types & Interfaces
+import {
+	ICXDataExchangeOption,
+	ICXDataTickerOption,
+} from "@/stores/planningStore.types";
+import {
+	ExchangeType,
+	PreferenceType,
+} from "@/features/exchanges/manageCX.types";
+import { SelectMixedOption } from "naive-ui/es/select/src/interface";
+
+export function useCXManagement() {
+	const gameDataStore = useGameDataStore();
+
+	const typeOptions: SelectMixedOption[] = [
+		{ label: "BOTH" as PreferenceType, value: "BOTH" },
+		{ label: "BUY" as PreferenceType, value: "BUY" },
+		{ label: "SELL" as PreferenceType, value: "SELL" },
+	];
+
+	const exchangeOptions: SelectMixedOption[] = [
+		{ label: "AI1 BUY" as ExchangeType, value: "AI1_BUY" },
+		{ label: "AI1 SELL" as ExchangeType, value: "AI1_SELL" },
+		{ label: "AI1 AVG" as ExchangeType, value: "AI1_AVG" },
+		{ label: "IC1 BUY" as ExchangeType, value: "IC1_BUY" },
+		{ label: "IC1 SELL" as ExchangeType, value: "IC1_SELL" },
+		{ label: "IC1 AVG" as ExchangeType, value: "IC1_AVG" },
+		{ label: "CI1 BUY" as ExchangeType, value: "CI1_BUY" },
+		{ label: "CI1 SELL" as ExchangeType, value: "CI1_SELL" },
+		{ label: "CI1 AVG" as ExchangeType, value: "CI1_AVG" },
+		{ label: "CI2 BUY" as ExchangeType, value: "CI2_BUY" },
+		{ label: "CI2 SELL" as ExchangeType, value: "CI2_SELL" },
+		{ label: "CI2 AVG" as ExchangeType, value: "CI2_AVG" },
+		{ label: "NC1 BUY" as ExchangeType, value: "NC1_BUY" },
+		{ label: "NC1 SELL" as ExchangeType, value: "NC1_SELL" },
+		{ label: "NC1 AVG" as ExchangeType, value: "NC1_AVG" },
+		{ label: "NC2 BUY" as ExchangeType, value: "NC2_BUY" },
+		{ label: "NC2 SELL" as ExchangeType, value: "NC2_SELL" },
+		{ label: "NC2 AVG" as ExchangeType, value: "NC2_AVG" },
+		{ label: "PP7D AI1" as ExchangeType, value: "PP7D_AI1" },
+		{ label: "PP7D IC1" as ExchangeType, value: "PP7D_IC1" },
+		{ label: "PP7D CI1" as ExchangeType, value: "PP7D_CI1" },
+		{ label: "PP7D CI2" as ExchangeType, value: "PP7D_CI2" },
+		{ label: "PP7D NC1" as ExchangeType, value: "PP7D_NC1" },
+		{ label: "PP7D NC2" as ExchangeType, value: "PP7D_NC2" },
+		{ label: "PP30D AI1" as ExchangeType, value: "PP30D_AI1" },
+		{ label: "PP30D IC1" as ExchangeType, value: "PP30D_IC1" },
+		{ label: "PP30D CI1" as ExchangeType, value: "PP30D_CI1" },
+		{ label: "PP30D CI2" as ExchangeType, value: "PP30D_CI2" },
+		{ label: "PP30D NC1" as ExchangeType, value: "PP30D_NC1" },
+		{ label: "PP30D NC2" as ExchangeType, value: "PP30D_NC2" },
+		{ label: "PP7D UNIVERSE" as ExchangeType, value: "PP7D_UNIVERSE" },
+		{ label: "PP30D UNIVERSE" as ExchangeType, value: "PP30D_UNIVERSE" },
+	];
+
+	const materialOptions: SelectMixedOption[] = gameDataStore
+		.getMaterials()
+		.map((e) => ({ label: e.Ticker, value: e.Ticker }));
+
+	/**
+	 * Checks if a specific exchange preference can be set depending
+	 * on other existing preferences, makes sure there is either BOTH
+	 * or SELL / BUY individually
+	 *
+	 * @author jplacht
+	 *
+	 * @param {ICXDataExchangeOption[]} current To check preferences
+	 * @param {PreferenceType} check Type to check for adding
+	 * @returns {ComputedRef<boolean>} Check Result
+	 */
+	const canAddExchangePreference = (
+		current: ICXDataExchangeOption[],
+		check: PreferenceType
+	): ComputedRef<boolean> =>
+		computed(() => {
+			if (current.length === 0) return true;
+
+			const types = current.map((e) => e.type);
+			if (check === "BOTH") {
+				return !types.includes("SELL") && !types.includes("BUY");
+			}
+			if (check === "BUY" || check === "SELL") {
+				return !types.includes("BOTH");
+			}
+
+			return false;
+		});
+
+	/**
+	 * Checks if a specific tickers preference can be set depending on
+	 * other existing preferences for this ticker, makes sure that there
+	 * is either a BOTH or SELL / BUY individually
+	 *
+	 * @author jplacht
+	 *
+	 * @param {ICXDataTickerOption[]} current Current Ticker Preferences
+	 * @param {string} checkTicker Ticker to Check
+	 * @param {PreferenceType} checkType Preference Type to Check
+	 * @returns {ComputedRef<boolean>} Check Result
+	 */
+	const canAddTickerPreference = (
+		current: ICXDataTickerOption[],
+		checkTicker: string,
+		checkType: PreferenceType
+	): ComputedRef<boolean> =>
+		computed(() => {
+			// check if options exist
+			const exist: ICXDataTickerOption[] = current.filter(
+				(e) => e.ticker === checkTicker
+			);
+
+			if (exist.length === 0) return true;
+
+			const existingTypes = exist.map((e) => e.type);
+			if (checkType === "BOTH") {
+				return (
+					!existingTypes.includes("SELL") &&
+					!existingTypes.includes("BUY")
+				);
+			} else if (checkType === "BUY" || checkType === "SELL") {
+				return !existingTypes.includes("BOTH");
+			}
+
+			return false;
+		});
+
+	/**
+	 * Updates an Exchange preference if allowed by either adding
+	 * or replacing it.
+	 *
+	 * @author jplacht
+	 *
+	 * @param {ICXDataExchangeOption[]} current Current Preferences
+	 * @param {PreferenceType} updateType Type to Update
+	 * @param {ExchangeType} updateExchange Exchange to Update
+	 * @returns {ICXDataExchangeOption[]} Updated Preferences
+	 */
+	function updateExchangePreference(
+		current: ICXDataExchangeOption[],
+		updateType: PreferenceType,
+		updateExchange: ExchangeType
+	): ICXDataExchangeOption[] {
+		if (canAddExchangePreference(current, updateType).value) {
+			const existing = current.find((e) => e.type === updateType);
+			if (existing) existing.exchange = updateExchange;
+			else {
+				current.push({ type: updateType, exchange: updateExchange });
+			}
+		}
+
+		return current;
+	}
+
+	/**
+	 * Updates a Ticker preference if allowed by either adding or
+	 * overwriting it
+	 *
+	 * @author jplacht
+	 *
+	 * @param {ICXDataTickerOption[]} current Current Preferences
+	 * @param {string} updateTicker Ticker to Update
+	 * @param {PreferenceType} updateType Type to Update
+	 * @param {number} updateValue Value to Update
+	 * @returns {ICXDataTickerOption[]} Updated Preferences
+	 */
+	function updateTickerPreference(
+		current: ICXDataTickerOption[],
+		updateTicker: string,
+		updateType: PreferenceType,
+		updateValue: number
+	): ICXDataTickerOption[] {
+		if (canAddTickerPreference(current, updateTicker, updateType).value) {
+			const existing = current.find(
+				(e) => e.ticker === updateTicker && e.type === updateType
+			);
+			if (existing) {
+				existing.type = updateType;
+				existing.value = updateValue;
+			} else {
+				current.push({
+					ticker: updateTicker,
+					type: updateType,
+					value: updateValue,
+				});
+			}
+		}
+
+		return current;
+	}
+
+	/**
+	 * Deletes an Exchange Preference Type
+	 *
+	 * @author jplacht
+	 *
+	 * @param {ICXDataExchangeOption[]} current Current Preferences
+	 * @param {PreferenceType} deleteType Type to delete
+	 * @returns {ICXDataExchangeOption[]} Updated Preferences
+	 */
+	function deleteExchangePreference(
+		current: ICXDataExchangeOption[],
+		deleteType: PreferenceType
+	): ICXDataExchangeOption[] {
+		return current.filter((o) => o.type !== deleteType);
+	}
+
+	/**
+	 * Deletes a Ticker Preference
+	 *
+	 * @author jplacht
+	 *
+	 * @param {ICXDataTickerOption[]} current Current Preferences
+	 * @param {string} deleteTicker Ticker to delete
+	 * @param {PreferenceType} deleteType Type to delete
+	 * @returns {ICXDataTickerOption[]} Updated Preferences
+	 */
+	function deleteTickerPreference(
+		current: ICXDataTickerOption[],
+		deleteTicker: string,
+		deleteType: PreferenceType
+	): ICXDataTickerOption[] {
+		return current.filter(
+			(o) => !(o.ticker === deleteTicker && o.type === deleteType)
+		);
+	}
+
+	return {
+		typeOptions,
+		exchangeOptions,
+		materialOptions,
+		canAddExchangePreference,
+		canAddTickerPreference,
+		updateExchangePreference,
+		updateTickerPreference,
+		deleteExchangePreference,
+		deleteTickerPreference,
+	};
+}

--- a/src/features/game_data/usePlanetData.ts
+++ b/src/features/game_data/usePlanetData.ts
@@ -8,6 +8,7 @@ import { inertClone } from "@/util/data";
 // Interfaces & Types
 import { IPlanet } from "@/features/api/gameData.types";
 import { IMaterialIOMinimal } from "@/features/planning/usePlanCalculation.types";
+import { BOUNDARY_DESCRIPTOR } from "@/util/numbers.types";
 
 /**
  * Planetary type static boundaries

--- a/src/features/manage/components/ManageCX.vue
+++ b/src/features/manage/components/ManageCX.vue
@@ -164,7 +164,7 @@
 		<x-n-data-table-column key="name" title="Name">
 			<template #render-cell="{ rowData }">
 				<router-link
-					:to="`/cx/${rowData.uuid}`"
+					:to="`/exchanges/${rowData.uuid}`"
 					class="text-link-primary font-bold hover:underline">
 					{{ rowData.name }}
 				</router-link>

--- a/src/features/navigation/components/NavigationBar.vue
+++ b/src/features/navigation/components/NavigationBar.vue
@@ -99,7 +99,7 @@
 				{
 					label: "Exchanges",
 					display: true,
-					routerLink: "/none",
+					routerLink: "/exchanges",
 					icon: ShoppingBasketSharp,
 				},
 				// {

--- a/src/features/wrapper/planningDataLoader.types.ts
+++ b/src/features/wrapper/planningDataLoader.types.ts
@@ -15,6 +15,7 @@ export type PlanningDataLoaderProps = {
 	readonly planetNaturalId?: string | undefined;
 	readonly planUuid?: string | undefined;
 	readonly loadCX?: boolean | undefined;
+	readonly cxUuid?: string | undefined;
 	readonly loadShared?: boolean | undefined;
 	readonly planList?: boolean | undefined;
 };
@@ -27,6 +28,7 @@ export type PlanningDataLoaderEmits = {
 	(e: "data:planet", data: IPlanet): void;
 	(e: "data:plan", data: IPlan): void;
 	(e: "data:plan:list", data: IPlan[]): void;
+	(e: "data:plan:list:planets", data: string[]): void;
 	(e: "data:cx", data: ICX[]): void;
 	(e: "data:shared", data: IShared[]): void;
 	(e: "update:cxUuid", data: string | undefined): void;
@@ -41,5 +43,5 @@ export type PlanningStepConfigsType = [
 	StepConfig<IPlanet>,
 	StepConfig<ICX[]>,
 	StepConfig<IShared[]>,
-	StepConfig<IPlan[]>,
+	StepConfig<IPlan[]>
 ];

--- a/src/features/wrapper/useGameDataLoader.ts
+++ b/src/features/wrapper/useGameDataLoader.ts
@@ -4,6 +4,9 @@ import { computed, reactive, ref, Ref, watch, watchEffect } from "vue";
 import { useQueryRepository } from "@/lib/query_cache/queryRepository";
 import { useQueryStore } from "@/lib/query_cache/queryStore";
 
+// Util
+import { inertClone } from "@/util/data";
+
 // Types & Interfaces
 import {
 	GameDataLoaderEmits,
@@ -18,7 +21,6 @@ import {
 	IPlanet,
 	IRecipe,
 } from "@/features/api/gameData.types";
-import { inertClone } from "@/util/data";
 
 export function useGameDataLoader(
 	props: GameDataLoaderProps,

--- a/src/lib/query_cache/queryRepository.ts
+++ b/src/lib/query_cache/queryRepository.ts
@@ -44,6 +44,7 @@ import {
 	callCreateCX,
 	callDeleteCX,
 	callGetCXList,
+	callPatchCX,
 	callUpdateCXJunctions,
 } from "@/features/api/cxData.api";
 import {
@@ -74,6 +75,7 @@ import {
 } from "@/features/manage/manage.types";
 import {
 	ICX,
+	ICXData,
 	IPlan,
 	IPlanEmpire,
 	IPlanEmpireElement,
@@ -315,6 +317,23 @@ export function useQueryRepository() {
 			autoRefetch: false,
 			persist: false,
 		} as QueryDefinition<{ junctions: ICXEmpireJunction[] }, ICX[]>,
+		PatchCX: {
+			key: (params: { cxUuid: string }) => [
+				"planningdata",
+				"cx",
+				"patch",
+				params.cxUuid,
+			],
+			fetchFn: async (params: { cxUuid: string; data: ICXData }) => {
+				const data = await callPatchCX(params.cxUuid, params.data);
+				queryStore.invalidateKey(["planningdata", "cx"], {
+					exact: false,
+				});
+				return data;
+			},
+			autoRefetch: false,
+			persist: false,
+		} as QueryDefinition<{ cxUuid: string; data: ICXData }, ICXData>,
 		GetAllEmpires: {
 			key: () => ["planningdata", "empire", "list"],
 			fetchFn: async () => {

--- a/src/lib/query_cache/queryRepository.types.ts
+++ b/src/lib/query_cache/queryRepository.types.ts
@@ -18,6 +18,7 @@ import {
 } from "@/features/manage/manage.types";
 import {
 	ICX,
+	ICXData,
 	IPlan,
 	IPlanEmpire,
 	IPlanEmpireElement,
@@ -71,6 +72,7 @@ export type QueryRepositoryType = {
 		{ junctions: ICXEmpireJunction[] },
 		ICX[]
 	>;
+	PatchCX: QueryDefinition<{ cxUuid: string; data: ICXData }, ICXData>;
 	GetAllEmpires: QueryDefinition<void, IPlanEmpireElement[]>;
 	GetEmpirePlans: QueryDefinition<{ empireUuid: string }, IPlan[]>;
 	PatchEmpire: QueryDefinition<

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -38,6 +38,13 @@ const router = createRouter({
 			component: () => import("@/views/ManageView.vue"),
 		},
 		{
+			name: "exchanges",
+			path: "/exchanges/:cxUuid?",
+			meta: { requiresAuth: true },
+			component: () => import("@/views/ExchangesView.vue"),
+			props: true,
+		},
+		{
 			name: "search",
 			path: "/search",
 			meta: { requiresAuth: true },

--- a/src/stores/gameDataStore.ts
+++ b/src/stores/gameDataStore.ts
@@ -93,6 +93,16 @@ export const useGameDataStore = defineStore(
 		}
 
 		/**
+		 * Gets all stored material information
+		 * @author jplacht
+		 *
+		 * @returns {IMaterial[]} Material Data
+		 */
+		function getMaterials(): IMaterial[] {
+			return inertClone(Object.values(materials.value));
+		}
+
+		/**
 		 * Sets material values by their Ticker
 		 * @author jplacht
 		 *
@@ -225,6 +235,7 @@ export const useGameDataStore = defineStore(
 			setFIOStorageData,
 			// functions
 			getPlanet,
+			getMaterials,
 		};
 	},
 	{

--- a/src/stores/planningStore.ts
+++ b/src/stores/planningStore.ts
@@ -137,7 +137,7 @@ export const usePlanningStore = defineStore(
 		function getCX(cxUuid: string): ICX {
 			const findCX = cxs.value[cxUuid];
 
-			if (findCX) return findCX;
+			if (findCX) return inertClone(findCX);
 
 			throw new Error(
 				`No data: CX '${cxUuid}'. Ensure CX uuid is valid and planning data has been loaded.`

--- a/src/tests/features/api/cxData.api.test.ts
+++ b/src/tests/features/api/cxData.api.test.ts
@@ -10,11 +10,14 @@ import {
 	callCreateCX,
 	callDeleteCX,
 	callGetCXList,
+	callPatchCX,
 	callUpdateCXJunctions,
 } from "@/features/api/cxData.api";
+import { ICXData } from "@/stores/planningStore.types";
 
 // test data
 import cx_list from "@/tests/test_data/api_data_cx_list.json";
+import cx_patch from "@/tests/test_data/api_data_exchange_patch.json";
 
 // mock apiService client
 const mock = new AxiosMockAdapter(apiService.client);
@@ -58,6 +61,17 @@ describe("CX Data API Calls", async () => {
 		mock.onPatch("/cx/junctions").reply(200, []);
 
 		expect(await callUpdateCXJunctions([])).toBeTruthy();
+		expect(spyApiServicePatch).toHaveBeenCalled();
+	});
+
+	it("callPatchCX", async () => {
+		const spyApiServicePatch = vi.spyOn(apiService, "patch");
+
+		const fakeUuid = "foo";
+
+		mock.onPatch(`/cx/${fakeUuid}`).reply(200, cx_patch as ICXData);
+
+		expect(await callPatchCX(fakeUuid, cx_patch as ICXData)).toBeTruthy();
 		expect(spyApiServicePatch).toHaveBeenCalled();
 	});
 });

--- a/src/tests/features/exchanges/useManageCX.test.ts
+++ b/src/tests/features/exchanges/useManageCX.test.ts
@@ -1,0 +1,193 @@
+import { describe, it, expect } from "vitest";
+
+import {
+	PreferenceType,
+	ExchangeType,
+} from "@/features/exchanges/manageCX.types";
+import {
+	ICXDataExchangeOption,
+	ICXDataTickerOption,
+} from "@/stores/planningStore.types";
+import { useCXManagement } from "@/features/exchanges/useManageCX";
+import { createPinia, setActivePinia } from "pinia";
+
+describe("useCXManagement", () => {
+	setActivePinia(createPinia());
+
+	const {
+		canAddExchangePreference,
+		canAddTickerPreference,
+		updateExchangePreference,
+		updateTickerPreference,
+		deleteExchangePreference,
+		deleteTickerPreference,
+	} = useCXManagement();
+
+	describe("canAddExchangePreference", () => {
+		it("should allow adding when list is empty", () => {
+			expect(canAddExchangePreference([], "BUY").value).toBe(true);
+		});
+
+		it("should not allow BOTH if BUY or SELL exists", () => {
+			const current: ICXDataExchangeOption[] = [
+				{ type: "BUY", exchange: "AI1_BUY" },
+			];
+			expect(canAddExchangePreference(current, "BOTH").value).toBe(false);
+		});
+
+		it("should not allow BUY if BOTH exists", () => {
+			const current: ICXDataExchangeOption[] = [
+				{ type: "BOTH", exchange: "AI1_AVG" },
+			];
+			expect(canAddExchangePreference(current, "BUY").value).toBe(false);
+		});
+
+		it("should allow SELL if only BUY exists", () => {
+			const current: ICXDataExchangeOption[] = [
+				{ type: "BUY", exchange: "AI1_BUY" },
+			];
+			expect(canAddExchangePreference(current, "SELL").value).toBe(true);
+		});
+
+		it("should return false for invalid preference type", () => {
+			const current: ICXDataExchangeOption[] = [
+				{ type: "BUY", exchange: "AI1_BUY" },
+			];
+			// @ts-expect-error: testing invalid input
+			expect(canAddExchangePreference(current, "INVALID").value).toBe(
+				false
+			);
+		});
+	});
+
+	describe("canAddTickerPreference", () => {
+		it("should allow adding when ticker is new", () => {
+			expect(canAddTickerPreference([], "LST", "BUY").value).toBe(true);
+		});
+
+		it("should not allow BOTH if BUY exists for ticker", () => {
+			const current: ICXDataTickerOption[] = [
+				{ ticker: "LST", type: "BUY", value: 10 },
+			];
+			expect(canAddTickerPreference(current, "LST", "BOTH").value).toBe(
+				false
+			);
+		});
+
+		it("should not allow SELL if BOTH exists for ticker", () => {
+			const current: ICXDataTickerOption[] = [
+				{ ticker: "LST", type: "BOTH", value: 10 },
+			];
+			expect(canAddTickerPreference(current, "LST", "SELL").value).toBe(
+				false
+			);
+		});
+
+		it("should allow SELL if only BUY exists for ticker", () => {
+			const current: ICXDataTickerOption[] = [
+				{ ticker: "LST", type: "BUY", value: 10 },
+			];
+			expect(canAddTickerPreference(current, "LST", "SELL").value).toBe(
+				true
+			);
+		});
+
+		it("should return false for invalid ticker preference type", () => {
+			const current: ICXDataTickerOption[] = [
+				{ ticker: "LST", type: "BUY", value: 100 },
+			];
+			expect(
+				// @ts-expect-error: testing invalid input
+				canAddTickerPreference(current, "LST", "INVALID").value
+			).toBe(false);
+		});
+	});
+
+	describe("updateExchangePreference", () => {
+		it("should add new preference", () => {
+			const current: ICXDataExchangeOption[] = [];
+			const updated = updateExchangePreference(current, "BUY", "AI1_BUY");
+			expect(updated).toContainEqual({
+				type: "BUY",
+				exchange: "AI1_BUY",
+			});
+		});
+
+		it("should update existing preference", () => {
+			const current: ICXDataExchangeOption[] = [
+				{ type: "BUY", exchange: "AI1_BUY" },
+			];
+			const updated = updateExchangePreference(current, "BUY", "IC1_BUY");
+			expect(updated).toContainEqual({
+				type: "BUY",
+				exchange: "IC1_BUY",
+			});
+		});
+
+		it("should not add if not allowed", () => {
+			const current: ICXDataExchangeOption[] = [
+				{ type: "BOTH", exchange: "AI1_AVG" },
+			];
+			const updated = updateExchangePreference(current, "BUY", "IC1_BUY");
+			expect(updated).toHaveLength(1);
+			expect(updated[0].exchange).toBe("AI1_AVG");
+		});
+	});
+
+	describe("updateTickerPreference", () => {
+		it("should add new ticker preference", () => {
+			const current: ICXDataTickerOption[] = [];
+			const updated = updateTickerPreference(current, "LST", "BUY", 100);
+			expect(updated).toContainEqual({
+				ticker: "LST",
+				type: "BUY",
+				value: 100,
+			});
+		});
+
+		it("should update existing ticker preference", () => {
+			const current: ICXDataTickerOption[] = [
+				{ ticker: "LST", type: "BUY", value: 50 },
+			];
+			const updated = updateTickerPreference(current, "LST", "BUY", 200);
+			expect(updated).toContainEqual({
+				ticker: "LST",
+				type: "BUY",
+				value: 200,
+			});
+		});
+
+		it("should not add if not allowed", () => {
+			const current: ICXDataTickerOption[] = [
+				{ ticker: "LST", type: "BOTH", value: 100 },
+			];
+			const updated = updateTickerPreference(current, "LST", "SELL", 50);
+			expect(updated).toHaveLength(1);
+			expect(updated[0].type).toBe("BOTH");
+		});
+	});
+
+	describe("deleteExchangePreference", () => {
+		it("should delete existing type", () => {
+			const current: ICXDataExchangeOption[] = [
+				{ type: "BUY", exchange: "AI1_BUY" },
+				{ type: "SELL", exchange: "AI1_SELL" },
+			];
+			const updated = deleteExchangePreference(current, "BUY");
+			expect(updated).toHaveLength(1);
+			expect(updated[0].type).toBe("SELL");
+		});
+	});
+
+	describe("deleteTickerPreference", () => {
+		it("should delete existing ticker+type", () => {
+			const current: ICXDataTickerOption[] = [
+				{ ticker: "LST", type: "BUY", value: 100 },
+				{ ticker: "LST", type: "SELL", value: 50 },
+			];
+			const updated = deleteTickerPreference(current, "LST", "BUY");
+			expect(updated).toHaveLength(1);
+			expect(updated[0].type).toBe("SELL");
+		});
+	});
+});

--- a/src/tests/test_data/api_data_exchange_patch.json
+++ b/src/tests/test_data/api_data_exchange_patch.json
@@ -1,0 +1,34 @@
+{
+	"name": "34",
+	"cx_empire": [
+		{ "type": "BUY", "exchange": "NC1_AVG" },
+		{ "type": "SELL", "exchange": "PP7D_AI1" }
+	],
+	"ticker_empire": [{ "type": "BUY", "ticker": "C", "value": 333 }],
+	"cx_planets": [
+		{
+			"planet": "UV-796b",
+			"preferences": [
+				{ "type": "BUY", "exchange": "NC1_AVG" },
+				{ "type": "SELL", "exchange": "PP30D_UNIVERSE" }
+			]
+		}
+	],
+	"ticker_planets": [
+		{
+			"planet": "QJ-684b",
+			"preferences": [{ "type": "SELL", "ticker": "STL", "value": 500 }]
+		},
+		{
+			"planet": "UV-796b",
+			"preferences": [
+				{ "type": "BUY", "ticker": "C", "value": 333 },
+				{ "type": "SELL", "ticker": "C", "value": 123 }
+			]
+		},
+		{
+			"planet": "OT-580c",
+			"preferences": [{ "type": "BOTH", "ticker": "LSE", "value": 25 }]
+		}
+	]
+}

--- a/src/views/ExchangesView.vue
+++ b/src/views/ExchangesView.vue
@@ -1,0 +1,247 @@
+<script setup lang="ts">
+	import { computed, ComputedRef, ref, Ref, watch } from "vue";
+
+	// Stores
+	import { usePlanningStore } from "@/stores/planningStore";
+
+	// Composables
+	import { useQuery } from "@/lib/query_cache/useQuery";
+	import { useQueryRepository } from "@/lib/query_cache/queryRepository";
+
+	// Util
+	import { inertClone } from "@/util/data";
+
+	// Components
+	import WrapperPlanningDataLoader from "@/features/wrapper/components/WrapperPlanningDataLoader.vue";
+	import WrapperGameDataLoader from "@/features/wrapper/components/WrapperGameDataLoader.vue";
+	import HelpDrawer from "@/features/help/components/HelpDrawer.vue";
+
+	import CXExchangePreference from "@/features/exchanges/components/CXExchangePreference.vue";
+	import CXTickerPreference from "@/features/exchanges/components/CXTickerPreference.vue";
+	import CXPlanetPreferenceTable from "@/features/exchanges/components/CXPlanetPreferenceTable.vue";
+
+	// Types & Interfaces
+	import { ICX, ICXData } from "@/stores/planningStore.types";
+	import { ICXPlanetMap } from "@/features/exchanges/manageCX.types";
+
+	// UI
+	import { NButton, NDropdown, NIcon, NInput } from "naive-ui";
+	import {
+		ArrowDropDownSharp,
+		SaveSharp,
+		ChangeCircleOutlined,
+	} from "@vicons/material";
+
+	// Unhead
+	import { useHead } from "@unhead/vue";
+
+	useHead({
+		title: `Exchanges | PRUNplanner`,
+	});
+
+	const planningStore = usePlanningStore();
+
+	const props = defineProps({
+		cxUuid: {
+			type: String,
+			required: false,
+			default: undefined,
+		},
+	});
+
+	const localCXUuid: Ref<string | undefined> = ref(props.cxUuid);
+	const localCXs: Ref<ICX[]> = ref([]);
+	const selectedCX: Ref<ICX | null> = ref(null);
+	const selectedName: Ref<string | null> = ref(null);
+	const rawSelectedCX: Ref<ICX | null> = ref(null);
+	const planetMap: Ref<ICXPlanetMap> = ref({});
+
+	const selectorDropdownOptions = computed(() =>
+		localCXs.value.map((c) => ({
+			label: c.name,
+			key: c.uuid,
+		}))
+	);
+
+	const cxName = computed(() => {
+		if (!localCXUuid.value) return "Exchanges";
+		return planningStore.getCX(localCXUuid.value).name;
+	});
+
+	const localPlanetList: Ref<string[]> = ref([]);
+
+	watch(
+		[() => localCXUuid.value, () => localPlanetList.value],
+		([cxUuid, planetList]) => {
+			if (cxUuid) {
+				selectedCX.value = planningStore.getCX(cxUuid);
+				selectedName.value = selectedCX.value.name;
+
+				// save raw, in order to re-use on "reload" button
+				rawSelectedCX.value = planningStore.getCX(cxUuid);
+				if (planetList.length > 0) {
+					generatePlanetMap(planetList);
+				}
+			}
+		},
+		{ immediate: true }
+	);
+
+	function generatePlanetMap(planetList: string[]): void {
+		planetMap.value = planetList.reduce((acc, planet) => {
+			acc[planet] = {
+				planet: planet,
+				exchanges:
+					selectedCX.value?.cx_data.cx_planets.find(
+						(e) => e.planet === planet
+					)?.preferences ?? [],
+				ticker:
+					selectedCX.value?.cx_data.ticker_planets.find(
+						(e) => e.planet === planet
+					)?.preferences ?? [],
+			};
+			return acc;
+		}, {} as ICXPlanetMap);
+	}
+
+	const patchData: ComputedRef<undefined | ICXData> = computed(() => {
+		const activeCX = selectedCX.value;
+		if (activeCX && selectedName.value && selectedName.value != "") {
+			const patch = {
+				name: selectedName.value,
+				cx_empire: activeCX.cx_data.cx_empire,
+				ticker_empire: activeCX.cx_data.ticker_empire,
+				cx_planets: Object.values(planetMap.value)
+					.map((p) => {
+						return {
+							planet: p.planet,
+							preferences: p.exchanges,
+						};
+					})
+					.filter((f) => f.preferences.length > 0),
+				ticker_planets: Object.values(planetMap.value)
+					.map((p) => {
+						return {
+							planet: p.planet,
+							preferences: p.ticker,
+						};
+					})
+					.filter((f) => f.preferences.length > 0),
+			};
+			return patch;
+		}
+		return undefined;
+	});
+
+	const isPatching: Ref<boolean> = ref(false);
+	async function patchCX(data: ICXData): Promise<void> {
+		if (selectedCX.value) {
+			isPatching.value = true;
+
+			await useQuery(useQueryRepository().repository.PatchCX, {
+				cxUuid: selectedCX.value.uuid,
+				data: data,
+			})
+				.execute()
+				.then(async () => {
+					await useQuery(
+						useQueryRepository().repository.GetAllCX
+					).execute();
+				})
+				.finally(() => (isPatching.value = false));
+		}
+	}
+
+	function reloadCXData(): void {
+		selectedCX.value = inertClone(rawSelectedCX.value);
+		selectedName.value = selectedCX.value!.name;
+		generatePlanetMap(localPlanetList.value);
+	}
+</script>
+
+<template>
+	<WrapperPlanningDataLoader
+		plan-list
+		load-c-x
+		:cx-uuid="props.cxUuid"
+		@update:cx-uuid="(cxUuid: string | undefined) => localCXUuid = cxUuid"
+		@data:cx="(data: ICX[]) => localCXs = data"
+		@data:plan:list:planets="(data: string[]) => localPlanetList = data">
+		<WrapperGameDataLoader load-exchanges load-materials>
+			<div class="min-h-screen flex flex-col">
+				<div
+					class="px-6 py-3 border-b border-white/10 flex flex-row justify-between gap-x-3">
+					<h1 class="text-2xl font-bold my-auto hover:cursor-pointer">
+						<n-dropdown
+							v-if="selectorDropdownOptions.length > 0"
+							trigger="hover"
+							:options="selectorDropdownOptions"
+							@select="(value: string) => localCXUuid = value">
+							<div>
+								<n-icon class="-mr-1">
+									<ArrowDropDownSharp />
+								</n-icon>
+								{{ cxName }}
+							</div>
+						</n-dropdown>
+						<template v-else>Exchanges</template>
+					</h1>
+					<div class="flex flex-row gap-x-3">
+						<n-button
+							v-if="patchData"
+							size="small"
+							:loading="isPatching"
+							@click="patchCX(patchData)">
+							<template #icon><SaveSharp /></template>
+							Save
+						</n-button>
+						<n-button size="small" @click="reloadCXData">
+							<template #icon><ChangeCircleOutlined /></template>
+							Reload
+						</n-button>
+						<HelpDrawer file-name="exchanges" />
+					</div>
+				</div>
+				<div v-if="!localCXUuid" class="px-6 pb-3 pt-4">
+					No Exchange Setting found. Head to Management and create
+					your first.
+				</div>
+				<div
+					v-else
+					:kex="`EXCHANGE#${localCXUuid}`"
+					class="flex-grow grid grid-cols-1 lg:grid-cols-[25%_auto] divide-x divide-white/10">
+					<div class="px-6 pb-3 pt-4 border-b border-white/10">
+						<h3 class="text-lg font-bold pb-3">Preference Name</h3>
+						<n-input
+							v-model:value="selectedName"
+							size="small"
+							:status="
+								!selectedName || selectedName === ''
+									? 'warning'
+									: 'success'
+							" />
+						<h2 class="text-xl font-bold py-3 pt-6 my-auto">
+							Empire Preferences
+						</h2>
+						<h3 class="text-lg font-bold pb-3">Exchange</h3>
+						<CXExchangePreference
+							v-if="selectedCX"
+							v-model:cx-options="selectedCX.cx_data.cx_empire" />
+						<h3 class="text-lg font-bold py-3">Ticker</h3>
+						<CXTickerPreference
+							v-if="selectedCX"
+							v-model:cx-options="
+								selectedCX.cx_data.ticker_empire
+							" />
+					</div>
+					<div class="p-6">
+						<CXPlanetPreferenceTable
+							v-if="selectedCX"
+							:key="selectedCX.uuid"
+							:planet-map="planetMap" />
+					</div>
+				</div>
+			</div>
+		</WrapperGameDataLoader>
+	</WrapperPlanningDataLoader>
+</template>


### PR DESCRIPTION
Introduces components and logic for managing exchange and ticker preferences at empire and planet levels. Adds new views, composables, types, tests, and API integration for patching CX data. Updates navigation, routing, and planning data loader to support exchange management workflows.

close #12