### PR TITLE
fix(plan): building production revenue calculation

### DIFF
--- a/src/features/planning/usePlanCalculation.ts
+++ b/src/features/planning/usePlanCalculation.ts
@@ -508,11 +508,7 @@ export function usePlanCalculation(
 
 			const productionRevenue: number =
 				productionMaterialIOEnhanced.reduce(
-					(sum, element) =>
-						sum +
-						(element.delta < 0
-							? element.price * -1
-							: element.price),
+					(sum, element) => sum + element.price,
 					0
 				);
 


### PR DESCRIPTION
the production material i/o enhanced already accounts for the amount of input and output in relation to the price, no double multiplication needed.

fix #90