### PR TITLE
feat(empire): planets not based on delta

### DIFF
--- a/src/features/empire/components/EmpireMaterialIO.vue
+++ b/src/features/empire/components/EmpireMaterialIO.vue
@@ -301,7 +301,9 @@
 								:to="`/plan/${p.planetId}/${p.planUuid}`"
 								class="hover:underline">
 								{{ getPlanetName(p.planetId) }}:
-								{{ formatNumber(p.value) }}
+								<strong>
+									{{ formatNumber(p.output) }}
+								</strong>
 							</router-link>
 						</template>
 						{{ p.planName }}
@@ -320,7 +322,9 @@
 								:to="`/plan/${p.planetId}/${p.planUuid}`"
 								class="hover:underline">
 								{{ getPlanetName(p.planetId) }}:
-								{{ formatNumber(p.value * -1) }}
+								<strong>
+									{{ formatNumber(p.input) }}
+								</strong>
 							</router-link>
 						</template>
 						{{ p.planName }}

--- a/src/features/empire/empire.types.d.ts
+++ b/src/features/empire/empire.types.d.ts
@@ -17,7 +17,9 @@ interface IEmpireMaterialIOPlanet {
 	planetId: string;
 	planUuid: string;
 	planName: string;
-	value: number;
+	delta: number;
+	input: number;
+	output: number;
 	price: number;
 }
 

--- a/src/features/planning/util/materialIO.util.ts
+++ b/src/features/planning/util/materialIO.util.ts
@@ -109,7 +109,9 @@ export function useMaterialIOUtil() {
 					planetId: planInfo.planetId,
 					planUuid: planInfo.planUuid,
 					planName: planInfo.planName,
-					value: element.delta,
+					delta: element.delta,
+					input: element.input,
+					output: element.output,
 					price: element.price,
 				};
 
@@ -117,13 +119,15 @@ export function useMaterialIOUtil() {
 				 * Delta check, handle delta === 0 separately, as the planet is
 				 * full consuming all its producing, so it needs to be on both sides
 				 */
-				if (element.delta < 0) {
+				if (element.input > 0) {
 					// only consuming
 					combinedMap[element.ticker].inputPlanets.push(planetPart);
-				} else if (element.delta > 0) {
+				}
+				if (element.output > 0) {
 					// only producing
 					combinedMap[element.ticker].outputPlanets.push(planetPart);
-				} else if (element.delta === 0) {
+				}
+				if (element.delta === 0) {
 					// full consuming all its producing
 					combinedMap[element.ticker].inputPlanets.push(planetPart);
 					combinedMap[element.ticker].outputPlanets.push(planetPart);
@@ -147,10 +151,10 @@ export function useMaterialIOUtil() {
 				.filter((v) => v);
 
 			const flatValues: number[] = flatPlanets.map((pv) =>
-				Math.abs(pv.value)
+				Math.abs(pv.delta)
 			);
 			const flatPrices: number[] = flatPlanets.map((pv) =>
-				Math.abs(pv.price / pv.value)
+				Math.abs(pv.price / pv.delta)
 			);
 			const sumValue: number = flatValues.reduce((sum, c) => sum + c, 0);
 			const sumProduct: number = flatPrices.reduce(

--- a/src/tests/features/planning/util/materialIO.util.test.ts
+++ b/src/tests/features/planning/util/materialIO.util.test.ts
@@ -14,10 +14,7 @@ import { IMaterialIOMinimal } from "@/features/planning/usePlanCalculation.types
 
 // test data
 import materials from "@/tests/test_data/api_data_materials.json";
-import {
-	IEmpireMaterialIO,
-	IEmpirePlanMaterialIO,
-} from "@/features/empire/empire.types";
+import { IEmpirePlanMaterialIO } from "@/features/empire/empire.types";
 
 describe("Util: materialIO ", async () => {
 	let gameDataStore: any;
@@ -230,8 +227,8 @@ describe("Util: materialIO ", async () => {
 		expect(result[0].deltaPrice).toBe(-10);
 		expect(result[0].input).toBe(3);
 		expect(result[0].output).toBe(3);
-		expect(result[0].inputPlanets.length).toBe(2);
-		expect(result[0].outputPlanets.length).toBe(0);
+		expect(result[0].inputPlanets.length).toBe(1);
+		expect(result[0].outputPlanets.length).toBe(1);
 	});
 	it("combineEmpireMaterialIO", async () => {
 		const fakeInput: IEmpirePlanMaterialIO[] = [
@@ -266,7 +263,7 @@ describe("Util: materialIO ", async () => {
 		expect(result[0].deltaPrice).toBe(0);
 		expect(result[0].input).toBe(10);
 		expect(result[0].output).toBe(10);
-		expect(result[0].inputPlanets.length).toBe(1);
-		expect(result[0].outputPlanets.length).toBe(1);
+		expect(result[0].inputPlanets.length).toBe(2);
+		expect(result[0].outputPlanets.length).toBe(2);
 	});
 });


### PR DESCRIPTION
uses input and output instead of delta to assign planets to production and consumption planets resulting in: if a planet produces and consumes, its listed in both columns.

close #111