### PR TITLE
feat(plan): implement construction cart, fix inertClone + tets

### DIFF
--- a/src/features/game_data/useMaterialData.ts
+++ b/src/features/game_data/useMaterialData.ts
@@ -9,6 +9,8 @@ import { inertClone } from "@/util/data";
 // Interfaces & Types
 import { IMaterial } from "@/features/api/gameData.types";
 
+const cache = new Map<string, IMaterial>();
+
 export function useMaterialData() {
 	const gameDataStore = useGameDataStore();
 
@@ -20,11 +22,18 @@ export function useMaterialData() {
 	 * @returns {IMaterial} Material Data
 	 */
 	function getMaterial(ticker: string): IMaterial {
+		// check internal cache
+		if (cache.has(ticker)) return cache.get(ticker)!;
+
 		const findMaterial: IMaterial | undefined = toRaw(
 			gameDataStore.materials[ticker]
 		);
 
-		if (findMaterial) return inertClone(findMaterial);
+		if (findMaterial) {
+			const data = inertClone(findMaterial);
+			cache.set(ticker, data);
+			return data;
+		}
 
 		throw new Error(
 			`No data: Material '${ticker}'. Ensure ticker is valid and game data has been loaded.`

--- a/src/features/planning/components/tools/PlanConstructionCart.vue
+++ b/src/features/planning/components/tools/PlanConstructionCart.vue
@@ -81,7 +81,7 @@
 	});
 
 	const buildingTicker = computed(() =>
-		props.constructionData.map((b) => b.ticker)
+		props.constructionData.map((b) => b.ticker).sort()
 	);
 
 	const totalMaterials = computed(() => {
@@ -105,7 +105,15 @@
 				props.productionBuildingData.find((pf) => pf.name === bticker)
 					?.amount ??
 				props.infrastructureData[bticker as INFRASTRUCTURE_TYPE] ??
-				0;
+				undefined;
+
+			// handle core module separately
+			if (
+				bticker === "CM" &&
+				localBuildingAmount.value["CM"] === undefined
+			) {
+				localBuildingAmount.value["CM"] = 1;
+			}
 
 			const thisMats = props.constructionData.find(
 				(e) => e.ticker === bticker

--- a/src/features/planning/components/tools/PlanConstructionCart.vue
+++ b/src/features/planning/components/tools/PlanConstructionCart.vue
@@ -1,0 +1,255 @@
+<script setup lang="ts">
+	import {
+		computed,
+		PropType,
+		Ref,
+		ref,
+		watchEffect,
+		ComputedRef,
+	} from "vue";
+
+	// Composables
+	import { useMaterialData } from "@/features/game_data/useMaterialData";
+	import { usePrice } from "@/features/cx/usePrice";
+
+	// Components
+	import MaterialTile from "@/features/material_tile/components/MaterialTile.vue";
+	import XITTransferActionButton from "@/features/xit/components/XITTransferActionButton.vue";
+
+	// Util
+	import { formatAmount, formatNumber } from "@/util/numbers";
+
+	// Types & Interfaces
+	import {
+		IBuildingConstruction,
+		INFRASTRUCTURE_TYPE,
+		IProductionBuilding,
+	} from "@/features/planning/usePlanCalculation.types";
+	import { IXITTransferMaterial } from "@/features/xit/xitAction.types";
+	import { IMaterial } from "@/features/api/gameData.types";
+
+	// UI
+	import { NButton, NTable, NInputNumber } from "naive-ui";
+	import { CloseSharp } from "@vicons/material";
+
+	const props = defineProps({
+		planetNaturalId: {
+			type: String,
+			required: true,
+		},
+		cxUuid: {
+			type: String,
+			required: false,
+			default: undefined,
+		},
+		constructionData: {
+			type: Array as PropType<IBuildingConstruction[]>,
+			required: true,
+		},
+		productionBuildingData: {
+			type: Array as PropType<IProductionBuilding[]>,
+			required: true,
+		},
+		infrastructureData: {
+			type: Object as PropType<Record<INFRASTRUCTURE_TYPE, number>>,
+			required: true,
+		},
+	});
+
+	const emit = defineEmits<{
+		(e: "close"): void;
+	}>();
+
+	const { getMaterial } = useMaterialData();
+	const { getPrice } = usePrice(
+		ref(props.cxUuid),
+		ref(props.planetNaturalId)
+	);
+
+	const localBuildingAmount: Ref<Record<string, number>> = ref({});
+	const localBuildingMaterials: Ref<Record<string, Record<string, number>>> =
+		ref({});
+
+	const uniqueMaterials = computed(() => {
+		return Array.from(
+			new Set(
+				props.constructionData
+					.map((e) => e.materials.map((x) => x.ticker))
+					.flat()
+			)
+		).sort();
+	});
+
+	const buildingTicker = computed(() =>
+		props.constructionData.map((b) => b.ticker)
+	);
+
+	const totalMaterials = computed(() => {
+		const r: Record<string, number> = {};
+		uniqueMaterials.value.map((mat) => {
+			r[mat] = 0;
+			buildingTicker.value.forEach((bticker) => {
+				if (localBuildingMaterials.value[bticker][mat]) {
+					r[mat] += localBuildingMaterials.value[bticker][mat];
+				}
+			});
+		});
+
+		return r;
+	});
+
+	function generateMatrix(): void {
+		buildingTicker.value.forEach((bticker) => {
+			localBuildingAmount.value[bticker] =
+				localBuildingAmount.value[bticker] ??
+				props.productionBuildingData.find((pf) => pf.name === bticker)
+					?.amount ??
+				props.infrastructureData[bticker as INFRASTRUCTURE_TYPE] ??
+				0;
+
+			const thisMats = props.constructionData.find(
+				(e) => e.ticker === bticker
+			);
+
+			if (thisMats) {
+				localBuildingMaterials.value[bticker] =
+					thisMats.materials.reduce((sum, current) => {
+						sum[current.ticker] =
+							current.input * localBuildingAmount.value[bticker];
+						return sum;
+					}, {} as Record<string, number>);
+			}
+		});
+	}
+
+	const xitTransferElements: ComputedRef<IXITTransferMaterial[]> = computed(
+		() =>
+			Object.entries(totalMaterials.value).map(([ticker, value]) => ({
+				ticker,
+				value,
+			}))
+	);
+
+	const totalInformation = computed(() => {
+		let weight: number = 0;
+		let volume: number = 0;
+		let price: number = 0;
+
+		xitTransferElements.value.forEach((m) => {
+			const materialInfo: IMaterial = getMaterial(m.ticker);
+			weight += materialInfo.Weight * m.value;
+			volume += materialInfo.Volume * m.value;
+
+			price += getPrice(m.ticker, "BUY") * m.value;
+		});
+
+		return { weight, volume, price };
+	});
+
+	watchEffect(() => generateMatrix());
+</script>
+
+<template>
+	<div class="pb-3 flex flex-row justify-between child:my-auto">
+		<h2 class="text-white/80 font-bold text-lg">Construction Cart</h2>
+		<div class="flex flex-row gap-x-3 child:!my-auto">
+			<XITTransferActionButton
+				:elements="xitTransferElements"
+				:drawer-width="400" />
+			<n-button size="tiny" secondary @click="emit('close')">
+				<template #icon><CloseSharp /></template>
+			</n-button>
+		</div>
+	</div>
+	<div class="overflow-auto">
+		<n-table class="table-auto overflow-scroll w-full">
+			<thead>
+				<tr>
+					<th>Building</th>
+					<th>Amount</th>
+					<th
+						v-for="mat in uniqueMaterials"
+						:key="`CONSTRUCTIONCART#COLUMN#${mat}`"
+						class="!text-center">
+						<MaterialTile :ticker="mat" />
+					</th>
+				</tr>
+			</thead>
+			<tbody>
+				<tr
+					v-for="building in buildingTicker"
+					:key="`CONSTRUCTIONCART#ROW#${building}`">
+					<th>{{ building }}</th>
+					<th class="!border-r">
+						<n-input-number
+							v-model:value="localBuildingAmount[building]"
+							show-button
+							:min="0"
+							size="small"
+							class="child:!bg-black min-w-[75px] max-w-[100px]" />
+					</th>
+					<td
+						v-for="mat in uniqueMaterials"
+						:key="`CONSTRUCTIONCART#COLUMN#${building}#${mat}`"
+						class="text-center">
+						<span
+							:class="
+								!localBuildingMaterials[building][mat]
+									? 'text-white/20'
+									: ''
+							">
+							{{
+								formatAmount(
+									localBuildingMaterials[building][mat] ?? 0
+								)
+							}}
+						</span>
+					</td>
+				</tr>
+				<tr class="child:!border-t-2 child:!border-b-2">
+					<td colspan="2">Materials Sum</td>
+					<td
+						v-for="mat in uniqueMaterials"
+						:key="`CONSTRUCTIONCART#COLUMN#TOTALS#${mat}`"
+						class="text-center font-bold">
+						{{ formatAmount(totalMaterials[mat] ?? 0) }}
+					</td>
+				</tr>
+				<tr>
+					<td :colspan="uniqueMaterials.length + 2">
+						<div
+							class="flex flex-row justify-between child:my-auto">
+							<div
+								class="grid grid-cols-2 gap-x-3 gap-y-1 child:not-even:font-bold">
+								<div>Total Cost</div>
+								<div>
+									{{ formatNumber(totalInformation.price) }}
+									<span class="pl-1 font-light text-white/50">
+										$
+									</span>
+								</div>
+							</div>
+							<div
+								class="grid grid-cols-2 gap-x-3 gap-y-1 child:text-end child:not-even:font-bold">
+								<div>Total Volume</div>
+								<div>
+									{{ formatNumber(totalInformation.volume) }}
+									<span class="pl-1 font-light text-white/50">
+										m³
+									</span>
+								</div>
+								<div>Total Weight</div>
+								<div>
+									{{ formatNumber(totalInformation.weight) }}
+									<span class="pl-1 font-light text-white/50">
+										t
+									</span>
+								</div>
+							</div>
+						</div>
+					</td>
+				</tr>
+			</tbody>
+		</n-table>
+	</div>
+</template>

--- a/src/features/planning/usePlanCalculation.ts
+++ b/src/features/planning/usePlanCalculation.ts
@@ -31,11 +31,13 @@ import { usePlanCalculationPreComputes } from "@/features/planning/usePlanCalcul
 import { IBuilding, IPlanet, IRecipe } from "@/features/api/gameData.types";
 import {
 	IAreaResult,
+	IBuildingConstruction,
 	IExpertRecord,
 	IInfrastructureRecord,
 	IMaterialIO,
 	IMaterialIOMaterial,
 	IMaterialIOMinimal,
+	INFRASTRUCTURE_TYPE,
 	IPlanResult,
 	IProductionBuilding,
 	IProductionBuildingRecipe,
@@ -117,15 +119,18 @@ export function usePlanCalculation(
 
 	// pre-computations
 
-	const { computedActiveEmpire, computedBuildingInformation } =
-		usePlanCalculationPreComputes(
-			buildings,
-			cxUuid,
-			empireUuid,
-			empireOptions,
-			planetNaturalId,
-			planetData
-		);
+	const {
+		computedActiveEmpire,
+		computedBuildingInformation,
+		infrastructureBuildingInformation,
+	} = usePlanCalculationPreComputes(
+		buildings,
+		cxUuid,
+		empireUuid,
+		empireOptions,
+		planetNaturalId,
+		planetData
+	);
 
 	// calculations
 
@@ -527,6 +532,33 @@ export function usePlanCalculation(
 		};
 	}
 
+	/**
+	 * Holds a computed array of all the plans buildings to be constructed
+	 * containing both production and infrastructure buildings
+	 *
+	 * @author jplacht
+	 *
+	 * @type {ComputedRef<IBuildingConstruction[]>} All building construction information
+	 */
+	const constructionMaterials: ComputedRef<IBuildingConstruction[]> =
+		computed(() => {
+			return [
+				...result.value.production.buildings.map((b) => ({
+					ticker: b.name,
+					materials: b.constructionMaterials,
+				})),
+				...infrastructureBuildingInformation.filter(
+					(i) =>
+						result.value.infrastructure[
+							i.ticker as INFRASTRUCTURE_TYPE
+						] &&
+						result.value.infrastructure[
+							i.ticker as INFRASTRUCTURE_TYPE
+						] > 0
+				),
+			];
+		});
+
 	// result composing
 
 	/**
@@ -658,6 +690,7 @@ export function usePlanCalculation(
 		backendData,
 		planEmpires,
 		planName,
+		constructionMaterials,
 		// precomputes
 		computedActiveEmpire,
 		// submodules

--- a/src/features/planning/usePlanCalculation.ts
+++ b/src/features/planning/usePlanCalculation.ts
@@ -549,12 +549,13 @@ export function usePlanCalculation(
 				})),
 				...infrastructureBuildingInformation.filter(
 					(i) =>
-						result.value.infrastructure[
+						(result.value.infrastructure[
 							i.ticker as INFRASTRUCTURE_TYPE
 						] &&
-						result.value.infrastructure[
-							i.ticker as INFRASTRUCTURE_TYPE
-						] > 0
+							result.value.infrastructure[
+								i.ticker as INFRASTRUCTURE_TYPE
+							] > 0) ||
+						i.ticker === "CM"
 				),
 			];
 		});

--- a/src/features/planning/usePlanCalculation.types.d.ts
+++ b/src/features/planning/usePlanCalculation.types.d.ts
@@ -142,3 +142,8 @@ interface IPreBuildingInformation {
 }
 
 export type IPreBuildingRecord = Record<string, IPreBuildingInformation>;
+
+export interface IBuildingConstruction {
+	ticker: string;
+	materials: IMaterialIOMinimal[];
+}

--- a/src/features/planning/usePlanCalculationPreComputes.ts
+++ b/src/features/planning/usePlanCalculationPreComputes.ts
@@ -11,10 +11,12 @@ import {
 	IPlanEmpireElement,
 } from "@/stores/planningStore.types";
 import {
+	IBuildingConstruction,
 	IMaterialIOMinimal,
 	IPreBuildingRecord,
 } from "@/features/planning/usePlanCalculation.types";
 import { IBuilding, IPlanet } from "@/features/api/gameData.types";
+import { infrastructureBuildingNames } from "@/features/planning/calculations/workforceCalculations";
 
 /**
  * # Precomputed References
@@ -84,8 +86,8 @@ export function usePlanCalculationPreComputes(
 	 *
 	 * @type {ComputedRef<string[]>} Array of Building Ticker
 	 */
-	const computedBuildingTicker: ComputedRef<string[]> = computed<string[]>(() =>
-		buildings.value.map((b) => b.name)
+	const computedBuildingTicker: ComputedRef<string[]> = computed<string[]>(
+		() => buildings.value.map((b) => b.name)
 	);
 
 	/**
@@ -116,7 +118,10 @@ export function usePlanCalculationPreComputes(
 				map[ticker] = {
 					ticker: ticker,
 					buildingData: buildingData,
-					buildingRecipes: getBuildingRecipes(ticker, planetData.Resources),
+					buildingRecipes: getBuildingRecipes(
+						ticker,
+						planetData.Resources
+					),
 					constructionMaterials: constructionMaterials,
 					constructionCost: getMaterialIOTotalPrice(
 						constructionMaterials,
@@ -129,9 +134,28 @@ export function usePlanCalculationPreComputes(
 			return map;
 		});
 
+	/**
+	 * Holds a record of all infrastructures construction materials
+	 * taking the planetary building requirements into account
+	 *
+	 * @author jplacht
+	 *
+	 * @type {IBuildingConstruction[]} Array of infrastructure
+	 * construction materials
+	 */
+	const infrastructureBuildingInformation: IBuildingConstruction[] =
+		infrastructureBuildingNames.map((inf) => ({
+			ticker: inf,
+			materials: getBuildingConstructionMaterials(
+				getBuilding(inf),
+				planetData
+			),
+		}));
+
 	return {
 		computedActiveEmpire,
 		computedBuildingTicker,
 		computedBuildingInformation,
+		infrastructureBuildingInformation,
 	};
 }

--- a/src/features/planning/usePlanCalculationPreComputes.ts
+++ b/src/features/planning/usePlanCalculationPreComputes.ts
@@ -143,14 +143,16 @@ export function usePlanCalculationPreComputes(
 	 * @type {IBuildingConstruction[]} Array of infrastructure
 	 * construction materials
 	 */
-	const infrastructureBuildingInformation: IBuildingConstruction[] =
-		infrastructureBuildingNames.map((inf) => ({
-			ticker: inf,
-			materials: getBuildingConstructionMaterials(
-				getBuilding(inf),
-				planetData
-			),
-		}));
+	const infrastructureBuildingInformation: IBuildingConstruction[] = [
+		"CM",
+		...infrastructureBuildingNames,
+	].map((inf) => ({
+		ticker: inf,
+		materials: getBuildingConstructionMaterials(
+			getBuilding(inf),
+			planetData
+		),
+	}));
 
 	return {
 		computedActiveEmpire,

--- a/src/stores/planningStore.ts
+++ b/src/stores/planningStore.ts
@@ -53,7 +53,7 @@ export const usePlanningStore = defineStore(
 			empires.value = {};
 			// store by Empire.uuid
 			empireList.forEach((e) => {
-				empires.value[e.uuid] = e;
+				empires.value[e.uuid] = inertClone(e);
 			});
 		}
 
@@ -100,7 +100,7 @@ export const usePlanningStore = defineStore(
 			cxs.value = {};
 			// store by CX.uuid
 			data.forEach((c) => {
-				cxs.value[c.uuid] = c;
+				cxs.value[c.uuid] = inertClone(c);
 			});
 		}
 
@@ -113,7 +113,7 @@ export const usePlanningStore = defineStore(
 		function setSharedList(data: IShared[]): void {
 			shared.value = {};
 			data.forEach((s) => {
-				shared.value[s.plan_uuid] = s;
+				shared.value[s.plan_uuid] = inertClone(s);
 			});
 		}
 
@@ -165,52 +165,25 @@ export const usePlanningStore = defineStore(
 		}
 
 		/**
-		 * Fetches all plans from the backend, stores them in this store
-		 * and then returns them as list
-		 * @author jplacht
-		 *
-		 * @async
-		 * @returns {Promise<IPlan[]>} Plan Data List
-		 */
-		async function getAllPlans(): Promise<IPlan[]> {
-			return inertClone(Object.values(plans.value));
-		}
-
-		/**
-		 * Gets all empires the user has either from previous fetch
-		 * or will load it again from the backend API
-		 * @author jplacht
-		 *
-		 * @async
-		 * @param {boolean} [force=false] Force Load from backend
-		 * @returns {Promise<IPlanEmpireElement[]>} Empire List
-		 */
-		async function getAllEmpires(): Promise<IPlanEmpireElement[]> {
-			return inertClone(Object.values(empires.value));
-		}
-
-		/**
 		 * Gets all exchange preferences either from store or directly from
 		 * the backend API if they were not fetched already
 		 *
 		 * @author jplacht
 		 *
-		 * @async
-		 * @returns {Promise<ICX[]>} CX Preference Data Array
+		 * @returns {ICX[]} CX Preference Data Array
 		 */
-		async function getAllCX(): Promise<ICX[]> {
-			return inertClone(Object.values(cxs.value));
+		function getAllCX(): ICX[] {
+			return Object.values(cxs.value);
 		}
 
 		/**
 		 * Gets all sharing information from backend
 		 * @author jplacht
 		 *
-		 * @async
-		 * @returns {Promise<ISharedPlan[]>} Sharing Information List
+		 * @returns {ISharedPlan[]} Sharing Information List
 		 */
-		async function getSharedList(): Promise<ISharedPlan[]> {
-			return inertClone(Object.values(shared.value));
+		function getSharedList(): ISharedPlan[] {
+			return Object.values(shared.value);
 		}
 
 		return {
@@ -232,9 +205,7 @@ export const usePlanningStore = defineStore(
 			// getters
 			getCX,
 			getPlan,
-			getAllEmpires,
 			getAllCX,
-			getAllPlans,
 			getSharedList,
 		};
 	},

--- a/src/tests/features/planning/usePlanCalculation.test.ts
+++ b/src/tests/features/planning/usePlanCalculation.test.ts
@@ -8,6 +8,9 @@ import { useGameDataStore } from "@/stores/gameDataStore";
 // Composables
 import { usePlanCalculation } from "@/features/planning/usePlanCalculation";
 
+// Util
+import { inertClone } from "@/util/data";
+
 // test data
 import plan_etherwind from "@/tests/test_data/api_data_plan_etherwind.json";
 import planet_etherwind from "@/tests/test_data/api_data_planet_etherwind.json";
@@ -71,6 +74,36 @@ describe("usePlanCalculation", async () => {
 			areaUsed: 994,
 			permits: 3,
 		});
+	});
+
+	it("validate constructionMaterials", async () => {
+		const { constructionMaterials } = usePlanCalculation(
+			// @ts-expect-error mock data
+			ref(plan_etherwind),
+			ref(undefined),
+			ref(undefined),
+			ref(undefined)
+		);
+		expect(constructionMaterials.value).toBeDefined();
+		expect(constructionMaterials.value.length).toBe(8);
+	});
+
+	it("unknown recipe error", async () => {
+		const manipData = inertClone(plan_etherwind);
+		manipData.baseplanner_data.buildings[0].active_recipes[0] = {
+			recipeid: "foo",
+			amount: 1,
+		};
+
+		const { result } = usePlanCalculation(
+			// @ts-expect-error mock data
+			ref(manipData),
+			ref(undefined),
+			ref(undefined),
+			ref(undefined)
+		);
+
+		expect(() => result.value).toThrowError();
 	});
 
 	it("validate existing and saveable", async () => {

--- a/src/tests/features/planning/usePlanCalculation.test.ts
+++ b/src/tests/features/planning/usePlanCalculation.test.ts
@@ -85,7 +85,7 @@ describe("usePlanCalculation", async () => {
 			ref(undefined)
 		);
 		expect(constructionMaterials.value).toBeDefined();
-		expect(constructionMaterials.value.length).toBe(8);
+		expect(constructionMaterials.value.length).toBe(9);
 	});
 
 	it("unknown recipe error", async () => {

--- a/src/tests/stores/planningStore.test.ts
+++ b/src/tests/stores/planningStore.test.ts
@@ -28,13 +28,6 @@ describe("Planning Store", async () => {
 			expect(Object.keys(planningStore.empires).length).toBe(2);
 		});
 
-		it("getAllEmpires", async () => {
-			planningStore.setEmpires(empire_list);
-			await expect(planningStore.getAllEmpires()).resolves.toStrictEqual(
-				empire_list
-			);
-		});
-
 		it("setPlan", async () => {
 			planningStore.setPlan(plan_etherwind);
 			const ewUuid: string = plan_etherwind.uuid;
@@ -66,9 +59,8 @@ describe("Planning Store", async () => {
 
 		it("setCXs", async () => {
 			planningStore.setCXs(cx_list);
-			await expect(planningStore.getAllCX()).resolves.toStrictEqual(
-				cx_list
-			);
+			const result = planningStore.getAllCX();
+			expect(result.length).toBe(cx_list.length);
 		});
 
 		it("getCX", async () => {
@@ -86,9 +78,9 @@ describe("Planning Store", async () => {
 
 		it("getSharedList", async () => {
 			planningStore.setSharedList(shared_list);
-			await expect(planningStore.getSharedList()).resolves.toStrictEqual(
-				shared_list
-			);
+			const result = planningStore.getSharedList();
+
+			expect(result).toStrictEqual(shared_list);
 		});
 
 		it("deleteShared", async () => {
@@ -112,14 +104,6 @@ describe("Planning Store", async () => {
 					planningStore.getPlan("foo")
 				).rejects.toThrowError();
 			});
-		});
-
-		it("getAllPlans", async () => {
-			planningStore.plans["foo"] = plan_etherwind;
-			planningStore.plans["moo"] = plan_etherwind;
-
-			const data = await planningStore.getAllPlans();
-			expect(data).toStrictEqual([plan_etherwind, plan_etherwind]);
 		});
 	});
 

--- a/src/views/PlanView.vue
+++ b/src/views/PlanView.vue
@@ -31,6 +31,7 @@
 	} = usePlan();
 
 	// Util
+	import { inertClone } from "@/util/data";
 	import { formatNumber } from "@/util/numbers";
 
 	// Components
@@ -79,7 +80,7 @@
 		},
 	});
 
-	const refPlanData: Ref<IPlan> = ref(props.planData);
+	const refPlanData: Ref<IPlan> = ref(inertClone(props.planData));
 	const refEmpireList: Ref<IPlanEmpireElement[] | undefined> = ref(
 		props.empireList
 	);
@@ -95,6 +96,7 @@
 		backendData,
 		computedActiveEmpire,
 		planEmpires,
+		constructionMaterials,
 		handleResetModified,
 		handleUpdateCorpHQ,
 		handleUpdateCOGC,
@@ -157,6 +159,7 @@
 		| "popr"
 		| "optimize-habitation"
 		| "supply-cart"
+		| "construction-cart"
 		| null;
 	const refShowTool: Ref<toolOptions> = ref(null);
 
@@ -263,6 +266,24 @@
 							),
 					},
 				};
+			case "construction-cart":
+				return {
+					component: defineAsyncComponent(
+						() =>
+							import(
+								"@/features/planning/components/tools/PlanConstructionCart.vue"
+							)
+					),
+					props: {
+						planetNaturalId: planetData.PlanetNaturalId,
+						cxUuid: refCXUuid.value,
+						constructionData: constructionMaterials.value,
+						productionBuildingData:
+							result.value.production.buildings,
+						infrastructureData: result.value.infrastructure,
+					},
+					listeners: {},
+				};
 			default:
 				return null;
 		}
@@ -335,6 +356,7 @@
 	// Unhead
 	import { useHead } from "@unhead/vue";
 	import { INFRASTRUCTURE_TYPE } from "@/features/planning/usePlanCalculation.types";
+
 	useHead({
 		title: computed(() =>
 			planName.value
@@ -507,9 +529,6 @@
 			</div>
 			<div class="border-b border-white/10 p-3">
 				<div class="flex grow justify-end gap-x-3 my-auto">
-					<n-button size="small" secondary disabled>
-						Empire Override
-					</n-button>
 					<n-button size="small" secondary @click="openTool('popr')">
 						POPR
 					</n-button>
@@ -519,7 +538,10 @@
 						@click="openTool('visitation-frequency')">
 						Visitation Frequency
 					</n-button>
-					<n-button size="small" secondary disabled>
+					<n-button
+						size="small"
+						secondary
+						@click="openTool('construction-cart')">
 						Construction Cart
 					</n-button>
 					<n-button


### PR DESCRIPTION
Introduces the PlanConstructionCart tool for summarizing building material requirements in planning. Adds a cache to useMaterialData for improved performance. Updates usePlanCalculation and related types to support construction material aggregation. Adjusts PlanView to support the new tool and fixes plan data mutation. Adds tests for constructionMaterials and error handling for unknown recipes.

close #23