### PR TITLE
refactor(core): reduce watch(), use computed()

### DIFF
--- a/src/features/exchanges/components/CXPreferenceSelector.vue
+++ b/src/features/exchanges/components/CXPreferenceSelector.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-	import { ref, Ref, watch } from "vue";
+	import { computed, WritableComputedRef } from "vue";
 
 	// Composables
 	import { useCXData } from "@/features/cx/useCXData";
@@ -27,15 +27,13 @@
 		(e: "update:cxuuid", value: string | undefined): void;
 	}>();
 
-	const localCXUuid: Ref<string | undefined> = ref(props.cxUuid);
+	const localCXUuid: WritableComputedRef<string | undefined> = computed({
+		get: () => props.cxUuid,
+		set: (value: string | undefined) => emit("update:cxuuid", value),
+	});
 
 	const preferenceOptions: SelectMixedOption[] =
 		useCXData().getPreferenceOptions(true);
-
-	watch(
-		() => props.cxUuid,
-		(newValue: string | undefined) => (localCXUuid.value = newValue)
-	);
 </script>
 
 <template>
@@ -44,6 +42,5 @@
 		:options="preferenceOptions"
 		clearable
 		filterable
-		:class="selectClass"
-		@update-value="(value: string | undefined) => emit('update:cxuuid', value)" />
+		:class="selectClass" />
 </template>

--- a/src/features/manage/components/ManageCX.vue
+++ b/src/features/manage/components/ManageCX.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-	import { computed, ComputedRef, PropType, ref, Ref, watch } from "vue";
+	import { computed, ComputedRef, PropType, ref, Ref } from "vue";
 
 	// Composables
 	import { useQueryRepository } from "@/lib/query_cache/queryRepository";
@@ -31,16 +31,8 @@
 		},
 	});
 
-	// Local Data & Watcher
-	const localCX: Ref<ICX[]> = ref(inertClone(props.cx));
-
-	watch(
-		() => props.cx,
-		(newData: ICX[]) => {
-			localCX.value = inertClone(newData);
-		},
-		{ deep: true }
-	);
+	// Local Data
+	const localCX: ComputedRef<ICX[]> = computed(() => inertClone(props.cx));
 
 	const refShowCreateCX: Ref<boolean> = ref(false);
 	const refIsCreating: Ref<boolean> = ref(false);

--- a/src/features/manage/components/ManageEmpire.vue
+++ b/src/features/manage/components/ManageEmpire.vue
@@ -55,29 +55,15 @@
 	});
 
 	// Local Data & Watcher
-	const localEmpires: Ref<IPlanEmpireElement[]> = ref(
+	const localEmpires: ComputedRef<IPlanEmpireElement[]> = computed(() =>
 		inertClone(props.empires)
 	);
-	const localCX: Ref<ICX[]> = ref(inertClone(props.cx));
+	const localCX: ComputedRef<ICX[]> = computed(() => inertClone(props.cx));
 
-	watch(
-		() => props.empires,
-		(newData: IPlanEmpireElement[]) => {
-			localEmpires.value = inertClone(newData);
-			generateCXOptions();
-			generateEmpireCXMap();
-		},
-		{ deep: true }
-	);
-	watch(
-		() => props.cx,
-		(newData: ICX[]) => {
-			localCX.value = inertClone(newData);
-			generateCXOptions();
-			generateEmpireCXMap();
-		},
-		{ deep: true }
-	);
+	watch([() => props.empires, () => props.cx], () => {
+		generateCXOptions();
+		generateEmpireCXMap();
+	});
 
 	const emit = defineEmits<{
 		(e: "update:cxList", value: ICX[]): void;
@@ -404,6 +390,7 @@
 			<template #render-cell="{ rowData }">
 				<div class="max-w-[200px]">
 					<n-select
+						:key="`${rowData.uuid}#${refEmpireCXMap[rowData.uuid]}`"
 						v-model:value="refEmpireCXMap[rowData.uuid]"
 						size="small"
 						:options="refCXOptions"

--- a/src/features/manage/components/ManagePlanEmpireAssignments.vue
+++ b/src/features/manage/components/ManagePlanEmpireAssignments.vue
@@ -1,5 +1,13 @@
 <script setup lang="ts">
-	import { computed, ComputedRef, PropType, ref, Ref, watch } from "vue";
+	import {
+		computed,
+		ComputedRef,
+		PropType,
+		ref,
+		Ref,
+		watch,
+		WritableComputedRef,
+	} from "vue";
 
 	// Composables
 	import { usePlanetData } from "@/features/game_data/usePlanetData";
@@ -47,28 +55,17 @@
 	});
 
 	// Local Data & Watcher
-	const localEmpires: Ref<IPlanEmpireElement[]> = ref(
-		inertClone(props.empires)
-	);
-	const localPlans: Ref<IPlan[]> = ref(inertClone(props.plans));
-
-	watch(
-		() => props.empires,
-		(newData: IPlanEmpireElement[]) => {
-			localEmpires.value = inertClone(newData);
-			generateMatrix();
-		},
-		{ deep: true }
+	const localEmpires: WritableComputedRef<IPlanEmpireElement[]> = computed({
+		get: () => inertClone(props.empires),
+		set: (value: IPlanEmpireElement[]) => emit("update:empireList", value),
+	});
+	const localPlans: ComputedRef<IPlan[]> = computed(() =>
+		inertClone(props.plans)
 	);
 
-	watch(
-		() => props.plans,
-		(newData: IPlan[]) => {
-			localPlans.value = inertClone(newData);
-			generateMatrix();
-		},
-		{ deep: true }
-	);
+	watch([() => props.empires, () => props.plans], () => {
+		generateMatrix();
+	});
 
 	const emit = defineEmits<{
 		(e: "update:empireList", value: IPlanEmpireElement[]): void;

--- a/src/features/planet_search/components/PlanetSearchResults.vue
+++ b/src/features/planet_search/components/PlanetSearchResults.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-	import { PropType, ref, Ref, watch } from "vue";
+	import { computed, ComputedRef, PropType } from "vue";
 
 	// Composables
 	import { usePlanetSearchResults } from "../usePlanetSearchResults";
@@ -33,39 +33,22 @@
 	});
 
 	// Local State
-	const localResults: Ref<IPlanetSearchResult[]> = ref(
-		usePlanetSearchResults(props.results, props.searchMaterials).results
-			.value
-	);
-	const localCheckDistances: Ref<string | null> = ref(
-		usePlanetSearchResults(props.results, props.searchMaterials)
-			.hasCheckDistance.value
-	);
-	const localSearchMaterials: Ref<string[]> = ref(props.searchMaterials);
-
-	watch(
-		() => props.results,
-		(newResults: IPlanet[]) => {
-			localResults.value = usePlanetSearchResults(
-				newResults,
-				localSearchMaterials.value
-			).results.value;
-			localCheckDistances.value = usePlanetSearchResults(
-				props.results,
-				localSearchMaterials.value
-			).hasCheckDistance.value;
-		}
+	const localSearchMaterials: ComputedRef<string[]> = computed(
+		() => props.searchMaterials
 	);
 
-	watch(
-		() => props.searchMaterials,
-		(newResults: string[]) => {
-			localSearchMaterials.value = newResults;
-			localResults.value = usePlanetSearchResults(
-				props.results,
-				newResults
-			).results.value;
-		}
+	const planetSearch: ComputedRef<{
+		results: ComputedRef<IPlanetSearchResult[]>;
+		hasCheckDistance: ComputedRef<string | null>;
+	}> = computed(() =>
+		usePlanetSearchResults(props.results, localSearchMaterials.value)
+	);
+
+	const localResults: ComputedRef<IPlanetSearchResult[]> = computed(
+		() => planetSearch.value.results.value
+	);
+	const localCheckDistances: ComputedRef<string | null> = computed(
+		() => planetSearch.value.hasCheckDistance.value
 	);
 </script>
 

--- a/src/features/planning/components/PlanArea.vue
+++ b/src/features/planning/components/PlanArea.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-	import { PropType, ref, Ref, watch } from "vue";
+	import { computed, PropType, WritableComputedRef } from "vue";
 
 	// Types & Interfaces
 	import { IAreaResult } from "@/features/planning/usePlanCalculation.types";
@@ -23,19 +23,9 @@
 	}>();
 
 	// Local State
-	const localPermits: Ref<number> = ref(props.areaData.permits);
-
-	// Prop Watcher
-	watch(
-		() => props.areaData.permits,
-		(newPermits: number) => {
-			localPermits.value = newPermits;
-		}
-	);
-
-	// Local Watcher & Emit
-	watch(localPermits, (newPermits: number) => {
-		emit("update:permits", newPermits);
+	const localPermits: WritableComputedRef<number> = computed({
+		get: () => props.areaData.permits,
+		set: (value: number) => emit("update:permits", value),
 	});
 </script>
 

--- a/src/features/planning/components/PlanBonuses.vue
+++ b/src/features/planning/components/PlanBonuses.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-	import { PropType, ref, Ref, watch } from "vue";
+	import { computed, PropType, WritableComputedRef } from "vue";
 
 	// Types & Interfaces
 	import { PLAN_COGCPROGRAM_TYPE } from "@/stores/planningStore.types";
@@ -29,31 +29,14 @@
 	}>();
 
 	// Local State
-	const localCorpHQ: Ref<boolean> = ref(props.corphq);
-	const localCOGC: Ref<PLAN_COGCPROGRAM_TYPE> = ref(props.cogc);
-
-	// Prop Watcher
-	watch(
-		() => props.corphq,
-		(newValue: boolean) => {
-			localCorpHQ.value = newValue;
-		}
-	);
-
-	watch(
-		() => props.cogc,
-		(newValue: PLAN_COGCPROGRAM_TYPE) => {
-			localCOGC.value = newValue;
-		}
-	);
-
-	// Local Watcher & Emit
-	watch(localCorpHQ, (newValue: boolean) => {
-		emit("update:corphq", newValue);
+	const localCorpHQ: WritableComputedRef<boolean> = computed({
+		get: () => props.corphq,
+		set: (value: boolean) => emit("update:corphq", value),
 	});
 
-	watch(localCOGC, (newValue: PLAN_COGCPROGRAM_TYPE) => {
-		emit("update:cogc", newValue);
+	const localCOGC: WritableComputedRef<PLAN_COGCPROGRAM_TYPE> = computed({
+		get: () => props.cogc,
+		set: (value: PLAN_COGCPROGRAM_TYPE) => emit("update:cogc", value),
 	});
 
 	const cogcOptions: SelectMixedOption[] = [

--- a/src/features/planning/components/PlanConfiguration.vue
+++ b/src/features/planning/components/PlanConfiguration.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-	import { PropType, ref, Ref, watch } from "vue";
+	import { computed, ComputedRef, PropType, WritableComputedRef } from "vue";
 
 	// Types & Interfaces
 	import { IPlanEmpire } from "@/stores/planningStore.types";
@@ -67,36 +67,20 @@
 	}>();
 
 	// Local State
-	const localPlanName: Ref<string | undefined> = ref(props.planName);
-	const localEmpireOptions: Ref<IPlanEmpire[] | undefined> = ref(
-		props.empireOptions
-	);
-	const localActiveEmpireUuid: Ref<string | undefined> = ref(
-		props.activeEmpire?.uuid
-	);
+	const localPlanName: WritableComputedRef<string | undefined> = computed({
+		get: () => props.planName,
+		set: (value: string | undefined) =>
+			value ? emit("update:plan-name", value) : {},
+	});
 
-	const empireSelectOptions: Ref<SelectMixedOption[]> = ref(
+	const localActiveEmpireUuid: WritableComputedRef<string | undefined> =
+		computed({
+			get: () => props.activeEmpire?.uuid,
+			set: (value: string) => emit("update:active-empire", value),
+		});
+
+	const empireSelectOptions: ComputedRef<SelectMixedOption[]> = computed(() =>
 		createEmpireOptions(props.empireOptions)
-	);
-
-	// Prop Watcher
-	watch(
-		() => props.planName,
-		(newName: string | undefined) => (localPlanName.value = newName)
-	);
-	watch(
-		() => props.empireOptions,
-		(newOptions: IPlanEmpire[] | undefined) => {
-			if (newOptions) {
-				localEmpireOptions.value = newOptions;
-				empireSelectOptions.value = createEmpireOptions(newOptions);
-			}
-		}
-	);
-	watch(
-		() => props.activeEmpire,
-		(newActiveEmpire: IPlanEmpire | undefined) =>
-			(localActiveEmpireUuid.value = newActiveEmpire?.uuid)
 	);
 </script>
 
@@ -108,20 +92,12 @@
 		label-align="left"
 		size="small">
 		<n-form-item label="Name">
-			<n-input
-				v-model:value="localPlanName"
-				placeholder="Plan Name"
-				:on-update:value="
-					(value: string) => emit('update:plan-name', value)
-				" />
+			<n-input v-model:value="localPlanName" placeholder="Plan Name" />
 		</n-form-item>
 		<n-form-item label="Empire">
 			<n-select
 				v-model:value="localActiveEmpireUuid"
-				:options="empireSelectOptions"
-				:on-update:value="
-					(value: string) => emit('update:active-empire', value)
-				" />
+				:options="empireSelectOptions" />
 		</n-form-item>
 	</n-form>
 </template>

--- a/src/features/planning/components/PlanExperts.vue
+++ b/src/features/planning/components/PlanExperts.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-	import { computed, PropType, ref, Ref, watch } from "vue";
+	import { computed, ComputedRef, PropType } from "vue";
 
 	// Types & Interfaces
 	import {
@@ -30,15 +30,8 @@
 	}>();
 
 	// Local State
-	const localExpertData: Ref<IExpertRecord> = ref(props.expertData);
-
-	// Prop Watcher
-	watch(
-		() => props.expertData,
-		(newData: IExpertRecord) => {
-			localExpertData.value = newData;
-		},
-		{ deep: true }
+	const localExpertData: ComputedRef<IExpertRecord> = computed(
+		() => props.expertData
 	);
 
 	const totalExperts = computed(() => {

--- a/src/features/planning/components/PlanInfrastructure.vue
+++ b/src/features/planning/components/PlanInfrastructure.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-	import { PropType, ref, Ref, watch } from "vue";
+	import { computed, ComputedRef, PropType } from "vue";
 
 	// Types & Interfaces
 	import {
@@ -30,18 +30,8 @@
 	}>();
 
 	// Local State
-	const localInfrastructureData: Ref<IInfrastructureRecord> = ref(
-		props.infrastructureData
-	);
-
-	// Prop Watcher
-	watch(
-		() => props.infrastructureData,
-		(newData: IInfrastructureRecord) => {
-			localInfrastructureData.value = newData;
-		},
-		{ deep: true }
-	);
+	const localInfrastructureData: ComputedRef<IInfrastructureRecord> =
+		computed(() => props.infrastructureData);
 
 	const infrastructureOrder: INFRASTRUCTURE_TYPE[] = [
 		"HB1",

--- a/src/features/planning/components/PlanMaterialIO.vue
+++ b/src/features/planning/components/PlanMaterialIO.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-	import { PropType, ref, Ref, watch } from "vue";
+	import { computed, ComputedRef, PropType } from "vue";
 
 	// Components
 	import MaterialTile from "@/features/material_tile/components/MaterialTile.vue";
@@ -25,23 +25,11 @@
 	});
 
 	// Local State
-	const localMaterialIOData: Ref<IMaterialIO[]> = ref(props.materialIOData);
-	const localShowBasked: Ref<boolean> = ref(props.showBasked);
-
-	// Prop Watcher
-	watch(
-		() => props.materialIOData,
-		(newData: IMaterialIO[]) => {
-			localMaterialIOData.value = newData;
-		},
-		{ deep: true }
+	const localMaterialIOData: ComputedRef<IMaterialIO[]> = computed(
+		() => props.materialIOData
 	);
-
-	watch(
-		() => props.showBasked,
-		(newState: boolean) => {
-			localShowBasked.value = newState;
-		}
+	const localShowBasked: ComputedRef<boolean> = computed(
+		() => props.showBasked
 	);
 </script>
 

--- a/src/features/planning/components/PlanProduction.vue
+++ b/src/features/planning/components/PlanProduction.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-	import { PropType, ref, Ref, watch } from "vue";
+	import { computed, ComputedRef, PropType, ref, Ref } from "vue";
 
 	// Composables
 	import { useBuildingData } from "@/features/game_data/useBuildingData";
@@ -55,27 +55,14 @@
 	}>();
 
 	// Local State
-	const localProductionData: Ref<IProductionResult> = ref(
-		props.productionData
+	const localProductionData: ComputedRef<IProductionResult> = computed(
+		() => props.productionData
 	);
 	const localSelectedBuilding: Ref<string | undefined> = ref(undefined);
-	const localCOGC: Ref<PLAN_COGCPROGRAM_TYPE> = ref("---");
+	const localCOGC: ComputedRef<PLAN_COGCPROGRAM_TYPE> = computed(
+		() => props.cogc
+	);
 	const localMatchCOGC: Ref<boolean> = ref(false);
-
-	// Prop Watcher
-	watch(
-		() => props.productionData,
-		(newData: IProductionResult) => {
-			localProductionData.value = newData;
-		},
-		{ deep: true }
-	);
-	watch(
-		() => props.cogc,
-		(newValue: PLAN_COGCPROGRAM_TYPE) => {
-			localCOGC.value = newValue;
-		}
-	);
 
 	const { getProductionBuildingOptions } = useBuildingData();
 </script>

--- a/src/features/planning/components/PlanProductionBuilding.vue
+++ b/src/features/planning/components/PlanProductionBuilding.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-	import { PropType, ref, Ref, watch } from "vue";
+	import { computed, ComputedRef, PropType } from "vue";
 
 	// Types & Interfaces
 	import { IProductionBuilding } from "@/features/planning/usePlanCalculation.types";
@@ -53,15 +53,8 @@
 	}>();
 
 	// Local State
-	const localBuildingData: Ref<IProductionBuilding> = ref(props.buildingData);
-
-	// Prop Watcher
-	watch(
-		() => props.buildingData,
-		(newData: IProductionBuilding) => {
-			localBuildingData.value = newData;
-		},
-		{ deep: true }
+	const localBuildingData: ComputedRef<IProductionBuilding> = computed(
+		() => props.buildingData
 	);
 </script>
 

--- a/src/features/planning/components/PlanProductionRecipe.vue
+++ b/src/features/planning/components/PlanProductionRecipe.vue
@@ -1,5 +1,12 @@
 <script setup lang="ts">
-	import { PropType, ref, Ref, watch } from "vue";
+	import {
+		computed,
+		ComputedRef,
+		PropType,
+		ref,
+		Ref,
+		WritableComputedRef,
+	} from "vue";
 
 	// Types & Interfaces
 	import {
@@ -48,40 +55,21 @@
 	}>();
 
 	// Local State
-	const localRecipeData: Ref<IProductionBuildingRecipe> = ref(
-		props.recipeData
+	const localRecipeOptions: ComputedRef<IRecipeBuildingOption[]> = computed(
+		() => props.recipeOptions
 	);
-	const localRecipeOptions: Ref<IRecipeBuildingOption[]> = ref(
-		props.recipeOptions
+	const localRecipeIndex: ComputedRef<number> = computed(() =>
+		props.recipeIndex.valueOf()
 	);
 
-	const localRecipeAmount: Ref<number> = ref(props.recipeData.amount);
-	const localRecipeIndex: Ref<number> = ref(props.recipeIndex.valueOf());
-
+	const localRecipeData: ComputedRef<IProductionBuildingRecipe> = computed(
+		() => props.recipeData
+	);
+	const localRecipeAmount: WritableComputedRef<number> = computed({
+		get: () => props.recipeData.amount,
+		set: () => {},
+	});
 	const refShowRecipeOptions: Ref<boolean> = ref(false);
-
-	// Prop Watcher
-	watch(
-		() => props.recipeData,
-		(newData: IProductionBuildingRecipe) => {
-			localRecipeData.value = newData;
-			localRecipeAmount.value = newData.amount;
-		},
-		{ deep: true }
-	);
-	watch(
-		() => props.recipeOptions,
-		(newData: IRecipeBuildingOption[]) => {
-			localRecipeOptions.value = newData;
-		},
-		{ deep: true }
-	);
-	watch(
-		() => props.recipeIndex,
-		(newIndex: number) => {
-			localRecipeIndex.value = newIndex;
-		}
-	);
 </script>
 
 <template>

--- a/src/features/planning/components/PlanWorkforce.vue
+++ b/src/features/planning/components/PlanWorkforce.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-	import { PropType, ref, Ref, watch } from "vue";
+	import { computed, ComputedRef, PropType } from "vue";
 
 	// Utils
 	import { capitalizeString } from "@/util/text";
@@ -36,15 +36,8 @@
 	}>();
 
 	// Local State
-	const localWorkforceData: Ref<IWorkforceRecord> = ref(props.workforceData);
-
-	// Prop Watcher
-	watch(
-		() => props.workforceData,
-		(newData: IWorkforceRecord) => {
-			localWorkforceData.value = newData;
-		},
-		{ deep: true }
+	const localWorkforceData: ComputedRef<IWorkforceRecord> = computed(
+		() => props.workforceData
 	);
 </script>
 
@@ -63,7 +56,9 @@
 		</thead>
 		<tbody>
 			<tr v-for="workforce in localWorkforceData" :key="workforce.name">
-				<td class="font-bold">{{ capitalizeString(workforce.name) }}</td>
+				<td class="font-bold">
+					{{ capitalizeString(workforce.name) }}
+				</td>
 				<td :class="workforce.required === 0 ? '!text-white/50' : ''">
 					{{ formatAmount(workforce.required) }}
 				</td>
@@ -80,9 +75,14 @@
 						size="tiny"
 						type="success"
 						@click="
-							() => emit('update:lux', workforce.name, 'lux1', !workforce.lux1)
-						"
-					>
+							() =>
+								emit(
+									'update:lux',
+									workforce.name,
+									'lux1',
+									!workforce.lux1
+								)
+						">
 						<template #icon>
 							<CheckSharp />
 						</template>
@@ -93,9 +93,14 @@
 						size="tiny"
 						type="error"
 						@click="
-							() => emit('update:lux', workforce.name, 'lux1', !workforce.lux1)
-						"
-					>
+							() =>
+								emit(
+									'update:lux',
+									workforce.name,
+									'lux1',
+									!workforce.lux1
+								)
+						">
 						<template #icon>
 							<RadioButtonUncheckedSharp />
 						</template>
@@ -108,9 +113,14 @@
 						size="tiny"
 						type="success"
 						@click="
-							() => emit('update:lux', workforce.name, 'lux2', !workforce.lux2)
-						"
-					>
+							() =>
+								emit(
+									'update:lux',
+									workforce.name,
+									'lux2',
+									!workforce.lux2
+								)
+						">
 						<template #icon>
 							<CheckSharp />
 						</template>
@@ -121,9 +131,14 @@
 						size="tiny"
 						type="error"
 						@click="
-							() => emit('update:lux', workforce.name, 'lux2', !workforce.lux2)
-						"
-					>
+							() =>
+								emit(
+									'update:lux',
+									workforce.name,
+									'lux2',
+									!workforce.lux2
+								)
+						">
 						<template #icon>
 							<RadioButtonUncheckedSharp />
 						</template>

--- a/src/features/xit/components/XITBurnActionButton.vue
+++ b/src/features/xit/components/XITBurnActionButton.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-	import { nextTick, PropType, ref, Ref, watch } from "vue";
+	import { computed, ComputedRef, nextTick, PropType, ref, Ref } from "vue";
 
 	// Composables
 	import { useBurnXITAction } from "@/features/xit/useBurnXITAction";
@@ -83,12 +83,8 @@
 	}
 
 	// Local State & Watcher
-	const localElements: Ref<IXITActionElement[]> = ref(props.elements);
-
-	watch(
-		() => props.elements,
-		(newElements: IXITActionElement[]) =>
-			(localElements.value = newElements)
+	const localElements: ComputedRef<IXITActionElement[]> = computed(
+		() => props.elements
 	);
 
 	const refHideInfinite: Ref<boolean> = ref(false);
@@ -221,7 +217,10 @@
 							<span
 								:class="
 									getBurnDisplayClass(e.burn).value != ''
-										? `${getBurnDisplayClass(e.burn).value} px-2 py-[3px]`
+										? `${
+												getBurnDisplayClass(e.burn)
+													.value
+										  } px-2 py-[3px]`
 										: ''
 								">
 								{{ formatNumber(e.burn) }}

--- a/src/features/xit/components/XITTransferActionButton.vue
+++ b/src/features/xit/components/XITTransferActionButton.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-	import { nextTick, PropType, ref, Ref, watch } from "vue";
+	import { nextTick, PropType, ref, Ref } from "vue";
 
 	// Composables
 	import { useXITAction } from "@/features/xit/useXITAction";
@@ -32,7 +32,7 @@
 		NSelect,
 	} from "naive-ui";
 
-	const props = defineProps({
+	defineProps({
 		elements: {
 			type: Array as PropType<IXITTransferMaterial[]>,
 			required: true,
@@ -76,15 +76,6 @@
 			nextTick().then(() => (showDrawer.value = true));
 		}
 	}
-
-	// Local State & Watcher
-	const localElements: Ref<IXITTransferMaterial[]> = ref(props.elements);
-
-	watch(
-		() => props.elements,
-		(newElements: IXITTransferMaterial[]) =>
-			(localElements.value = newElements)
-	);
 </script>
 
 <template>


### PR DESCRIPTION
Replaces most usages of ref and watch for local state mirroring props with computed and WritableComputedRef, simplifying reactivity and reducing boilerplate.

close #137