### PR TITLE
feat(material): cx data popover table

### DIFF
--- a/src/features/cx/components/MaterialCXOverviewTable.vue
+++ b/src/features/cx/components/MaterialCXOverviewTable.vue
@@ -1,0 +1,97 @@
+<script setup lang="ts">
+	import { PropType } from "vue";
+
+	// Composables
+	import { useExchangeData } from "@/features/game_data/useExchangeData";
+	const { exchangeTypesArray } = useExchangeData();
+
+	// Util
+	import { formatNumber } from "@/util/numbers";
+
+	// Types & Interfaces
+	import { IMaterialExchangeOverview } from "@/features/game_data/useMaterialData.types";
+
+	// UI
+	import { NTable } from "naive-ui";
+
+	defineProps({
+		ticker: {
+			type: String,
+			required: true,
+		},
+		overviewData: {
+			type: Object as PropType<IMaterialExchangeOverview>,
+			required: true,
+		},
+	});
+</script>
+
+<template>
+	<n-table :key="`CX#OverviewTable#${ticker}`" striped>
+		<thead>
+			<tr>
+				<th>{{ ticker }}</th>
+				<th>AI1</th>
+				<th>CI1</th>
+				<th>IC1</th>
+				<th>NC1</th>
+			</tr>
+		</thead>
+		<tbody class="child:child:first:font-bold">
+			<tr>
+				<td>Ask</td>
+				<td v-for="cx in exchangeTypesArray" :key="`Ask#${cx}`">
+					{{ formatNumber(overviewData.Ask[cx], 2, true) }}
+				</td>
+			</tr>
+			<tr>
+				<td>Bid</td>
+				<td v-for="cx in exchangeTypesArray" :key="`Bid#${cx}`">
+					{{ formatNumber(overviewData.Bid[cx], 2, true) }}
+				</td>
+			</tr>
+			<tr>
+				<td>Average</td>
+				<td v-for="cx in exchangeTypesArray" :key="`Average#${cx}`">
+					{{ formatNumber(overviewData.Average[cx], 2, true) }}
+				</td>
+			</tr>
+			<tr>
+				<td>PP7D</td>
+				<td v-for="cx in exchangeTypesArray" :key="`PP7D#${cx}`">
+					{{ formatNumber(overviewData.PP7D[cx], 2, true) }}
+				</td>
+			</tr>
+			<tr>
+				<td>PP30D</td>
+				<td v-for="cx in exchangeTypesArray" :key="`PP30D#${cx}`">
+					{{ formatNumber(overviewData.PP30D[cx], 2, true) }}
+				</td>
+			</tr>
+			<tr>
+				<td>7D Universe</td>
+				<td colspan="4" class="text-center">
+					{{ formatNumber(overviewData.Universe7D, 2, true) }}
+				</td>
+			</tr>
+			<tr>
+				<td>30D Universe</td>
+				<td colspan="4" class="text-center">
+					{{ formatNumber(overviewData.Universe30D, 2, true) }}
+				</td>
+			</tr>
+			<tr>
+				<td>Supply</td>
+				<td v-for="cx in exchangeTypesArray" :key="`Supply#${cx}`">
+					{{ formatNumber(overviewData.Supply[cx], 2, true) }}
+				</td>
+			</tr>
+			<tr>
+				<td>Demand</td>
+				<td v-for="cx in exchangeTypesArray" :key="`Demand#${cx}`">
+					{{ formatNumber(overviewData.Demand[cx], 2, true) }}
+				</td>
+			</tr>
+		</tbody>
+	</n-table>
+</template>

--- a/src/layout/prunplannerNaiveUI.ts
+++ b/src/layout/prunplannerNaiveUI.ts
@@ -165,10 +165,13 @@ export const prunplannerTheme: GlobalThemeOverrides = {
 		// color
 		thColor: GRAY_DARK,
 		thColorModal: GRAY_DARK,
+		thColorPopover: GRAY_DARK,
 		tdColorStriped: GRAY_DARK,
 		tdColorStripedModal: GRAY_DARK,
+		tdColorStripedPopover: GRAY_DARK,
 		tdColor: "rgba(255,255,255,0.02)",
 		tdColorModal: "rgba(255,255,255,0.02)",
+		tdColorPopover: "rgba(255,255,255,0.02)",
 		// padding
 		thPaddingMedium: "5px 10px",
 		tdPaddingMedium: "5px 10px",


### PR DESCRIPTION
Introduced MaterialCXOverviewTable.vue for displaying material exchange data. Refactored MaterialTile.vue to use the new table component and added popover support for market overview. Updated prunplannerNaiveUI.ts to support popover table theme overrides.

close #140