### PR TITLE
Fix BEN bonus calculation

### DIFF
--- a/src/features/planning/calculations/bonusCalculations.ts
+++ b/src/features/planning/calculations/bonusCalculations.ts
@@ -74,7 +74,7 @@ export function useBonusCalculation() {
 			ELECTRONICS: 0.05,
 		},
 		BENTEN: {
-			MANUFACTURING: 0.5,
+			MANUFACTURING: 0.05,
 		},
 		HORTUS: {
 			AGRICULTURE: 0.03,


### PR DESCRIPTION
I noticed that my BMP's time was off by 50%.

Verified with https://handbook.apex.prosperousuniverse.com/wiki/headquarters/index.html and the numbers against v1. I can't quite tell why all the numbers are halved from the wiki, but it's consistent