### PR TITLE
feat(plan): cogm, without exchange views in modal

### DIFF
--- a/src/features/planning/components/PlanProductionRecipe.vue
+++ b/src/features/planning/components/PlanProductionRecipe.vue
@@ -20,9 +20,10 @@
 
 	// Components
 	import MaterialTile from "@/features/material_tile/components/MaterialTile.vue";
+	import PlanCOGM from "@/features/planning/components/tools/PlanCOGM.vue";
 
 	// UI
-	import { NInputNumber, NButton, NTable } from "naive-ui";
+	import { NModal, NInputNumber, NButton, NTable } from "naive-ui";
 	import { ClearSharp, AnalyticsOutlined } from "@vicons/material";
 
 	const props = defineProps({
@@ -70,9 +71,20 @@
 		set: () => {},
 	});
 	const refShowRecipeOptions: Ref<boolean> = ref(false);
+	const refShowCOGM: Ref<boolean> = ref(false);
 </script>
 
 <template>
+	<n-modal
+		:key="`COGM#RECIPE#${recipeData.recipe.BuildingTicker}#${localRecipeIndex}`"
+		v-model:show="refShowCOGM"
+		preset="card"
+		title="Cost Of Goods Manufactured"
+		class="max-w-[600px]">
+		<PlanCOGM
+			v-if="localRecipeData.cogm"
+			:cogm-data="localRecipeData.cogm" />
+	</n-modal>
 	<div>
 		<n-input-number
 			v-model:value="localRecipeAmount"
@@ -98,7 +110,7 @@
 			"
 			class="border border-pp-border my-3 p-3 flex flex-row justify-between child:my-auto hover:cursor-pointer"
 			@click="refShowRecipeOptions = true">
-			<div class="flex gap-x-1">
+			<div class="flex flex-col gap-1">
 				<MaterialTile
 					v-for="material in localRecipeData.recipe.Outputs"
 					:key="`${localRecipeData.recipe.BuildingTicker}#${material.Ticker}`"
@@ -214,7 +226,12 @@
 		</div>
 
 		<div class="mb-3 flex flex-row justify-between child:my-auto">
-			<n-button size="tiny">
+			<n-button
+				size="tiny"
+				:disabled="
+					localRecipeData.cogm && !localRecipeData.cogm.visible
+				"
+				@click="() => (refShowCOGM = true)">
 				<template #icon><AnalyticsOutlined /> </template>
 			</n-button>
 			<n-button

--- a/src/features/planning/components/tools/PlanCOGM.vue
+++ b/src/features/planning/components/tools/PlanCOGM.vue
@@ -1,0 +1,153 @@
+<script setup lang="ts">
+	import { ComputedRef, computed, PropType } from "vue";
+
+	// Components
+	import MaterialTile from "@/features/material_tile/components/MaterialTile.vue";
+
+	// Types & Interfaces
+	import { IProductionBuildingRecipeCOGM } from "@/features/planning/usePlanCalculation.types";
+
+	// Util
+	import { humanizeTimeMs } from "@/util/date";
+	import { formatNumber } from "@/util/numbers";
+
+	// UI
+	import { NTable } from "naive-ui";
+
+	const props = defineProps({
+		cogmData: {
+			type: Object as PropType<IProductionBuildingRecipeCOGM>,
+			required: true,
+		},
+	});
+
+	const data: ComputedRef<IProductionBuildingRecipeCOGM> = computed(
+		() => props.cogmData
+	);
+</script>
+
+<template>
+	<div class="pb-2 text-white/50 text-xs">
+		The cost of goods manufactured is calculated using plan settings that
+		factor in production efficiency, recipe runtime, building degradation,
+		input material costs, labor requirements, and associated labor costs.
+		The final cost is shown per unit of output, based on quantity or full
+		cost allocation.
+	</div>
+	<n-table>
+		<tbody>
+			<tr>
+				<th colspan="4">Parameters</th>
+			</tr>
+			<tr>
+				<td class="!border-r">Recipe Runtime</td>
+				<td>{{ humanizeTimeMs(data.runtime) }}</td>
+				<td colspan="2" class="text-end">
+					{{ formatNumber(data.runtimeShare * 100) }} % / day
+				</td>
+			</tr>
+			<tr>
+				<td class="!border-r">Efficiency</td>
+				<td colspan="3">{{ formatNumber(data.efficiency * 100) }} %</td>
+			</tr>
+			<tr>
+				<th colspan="4">Cost</th>
+			</tr>
+			<tr>
+				<td class="!border-r">Degradation</td>
+				<td class="font-bold">
+					{{ formatNumber(data.degradationShare) }}
+					<span class="pl-1 font-light text-white/50"> $ </span>
+				</td>
+				<td colspan="2" class="text-end">
+					{{ formatNumber(data.runtimeShare * 100) }} % /
+					{{ formatNumber(data.degradation) }}
+					<span class="pl-1 font-light text-white/50"> $ </span>
+				</td>
+			</tr>
+			<template v-if="data.inputCost.length > 0">
+				<tr>
+					<td :rowspan="data.inputCost.length + 2" class="!border-r">
+						Materials
+					</td>
+					<td>Input Total</td>
+					<td colspan="2" class="text-end font-bold">
+						{{ formatNumber(data.inputTotal) }}
+						<span class="pl-1 font-light text-white/50"> $ </span>
+					</td>
+				</tr>
+				<tr>
+					<td>Material</td>
+					<td>$ / Unit</td>
+					<td class="text-end">$ Total</td>
+				</tr>
+				<tr
+					v-for="input in data.inputCost"
+					:key="`INPUT#${input.ticker}`">
+					<td>
+						<MaterialTile
+							:ticker="input.ticker"
+							:amount="input.amount" />
+					</td>
+					<td>
+						{{ formatNumber(input.costUnit) }}
+						<span class="pl-1 font-light text-white/50"> $ </span>
+					</td>
+					<td class="text-end">
+						{{ formatNumber(input.costTotal) }}
+						<span class="pl-1 font-light text-white/50"> $ </span>
+					</td>
+				</tr>
+			</template>
+			<tr>
+				<td class="!border-r">Workforce</td>
+				<td class="font-bold">
+					{{ formatNumber(data.workforceCost) }}
+					<span class="pl-1 font-light text-white/50"> $ </span>
+				</td>
+				<td colspan="2" class="text-end">
+					{{ formatNumber(data.runtimeShare * 100) }} % /
+					{{ formatNumber(data.workforceCostTotal) }}
+					<span class="pl-1 font-light text-white/50"> $ </span>
+				</td>
+			</tr>
+			<tr>
+				<td class="!border-r">Total Cost</td>
+				<td colspan="3" class="font-bold">
+					{{ formatNumber(data.totalCost) }}
+					<span class="pl-1 font-light text-white/50"> $ </span>
+				</td>
+			</tr>
+			<tr>
+				<th colspan="4">Cost of Goods Manufactured</th>
+			</tr>
+			<tr>
+				<td
+					:rowspan="data.outputCOGM.length + 1"
+					class="!border-b-0 !border-r">
+					COGM
+				</td>
+				<td>Material</td>
+				<td>Cost Split</td>
+				<td class="text-end">Cost Total</td>
+			</tr>
+			<tr
+				v-for="output in data.outputCOGM"
+				:key="`OUTPUT#${output.ticker}`">
+				<td>
+					<MaterialTile
+						:ticker="output.ticker"
+						:amount="output.amount" />
+				</td>
+				<td>
+					{{ formatNumber(output.costSplit) }}
+					<span class="pl-1 font-light text-white/50"> $ </span>
+				</td>
+				<td class="text-end">
+					{{ formatNumber(output.costTotal) }}
+					<span class="pl-1 font-light text-white/50"> $ </span>
+				</td>
+			</tr>
+		</tbody>
+	</n-table>
+</template>

--- a/src/features/planning/usePlanCalculation.types.d.ts
+++ b/src/features/planning/usePlanCalculation.types.d.ts
@@ -70,12 +70,42 @@ export interface IRecipeBuildingOption extends IRecipe {
 	roi: number;
 }
 
+interface ICOGMMaterialCost {
+	ticker: string;
+	amount: number;
+	costUnit: number;
+	costTotal: number;
+}
+
+interface ICOGMMaterialReturn {
+	ticker: string;
+	amount: number;
+	costSplit: number;
+	costTotal: number;
+}
+
+export interface IProductionBuildingRecipeCOGM {
+	visible: boolean;
+	runtime: number;
+	runtimeShare: number;
+	efficiency: number;
+	degradation: number;
+	degradationShare: number;
+	workforceCost: number;
+	workforceCostTotal: number;
+	inputCost: ICOGMMaterialCost[];
+	inputTotal: number;
+	outputCOGM: ICOGMMaterialReturn[];
+	totalCost: number;
+}
+
 export interface IProductionBuildingRecipe {
 	recipeId: string;
 	amount: number;
 	recipe: IRecipeBuildingOption;
 	dailyShare: number;
 	time: number;
+	cogm: IProductionBuildingRecipeCOGM | undefined;
 }
 
 export interface IProductionBuilding {


### PR DESCRIPTION
Introduces Cost Of Goods Manufactured (COGM) calculation for production recipes in usePlanCalculation, including new types for COGM data. Adds PlanCOGM.vue component and integrates a modal in PlanProductionRecipe.vue to display detailed COGM breakdown per recipe. Updates types to support COGM data in recipe objects.

close #27 