### PR TITLE
feat(help): add help and changelog, more markdown

### DIFF
--- a/src/assets/css/style.css
+++ b/src/assets/css/style.css
@@ -80,6 +80,10 @@ html {
 	@apply pb-3 text-white/20;
 }
 
+#markdown a {
+	@apply text-link-primary hover:underline;
+}
+
 /** HIGHCHARTS **/
 
 .highcharts-point-up {

--- a/src/assets/help/changelog.md
+++ b/src/assets/help/changelog.md
@@ -1,0 +1,19 @@
+# 2025-08-11
+
+- Add Help & Changelog page, listing most recent changes
+- Implement COGM calculations and modal on plan active recipes, excluding ability to change ticker preferences for now [#27](https://github.com/PRUNplanner/frontend/issues/27)
+- Fix Benten manufacturing faction bonus (by `lilbit-prun`) [#142](https://github.com/PRUNplanner/frontend/pull/142)
+
+# 2025-08-10
+
+- Add CX Data popover on material tiles [#140](https://github.com/PRUNplanner/frontend/issues/140)
+
+# 2025-08-08
+
+- Fix an issue where adding a recipe produces a lag due to gamedata wrappers being retriggered on MaterialTiles
+- Reduces the usage of `watch` in favor of `computed` [#138](https://github.com/PRUNplanner/frontend/issues/137)
+
+# 2028-08-07
+
+- Implement HQ Upgrade Cost Calculator [#128](https://github.com/PRUNplanner/frontend/issues/128)
+

--- a/src/assets/help/empire.md
+++ b/src/assets/help/empire.md
@@ -1,0 +1,3 @@
+Needs to be written.
+
+Also mention the way how empire material i/o is using individual plans price data

--- a/src/assets/help/tools_hq_upgrade_calculator.md
+++ b/src/assets/help/tools_hq_upgrade_calculator.md
@@ -1,0 +1,1 @@
+Needs to be written

--- a/src/assets/help/tools_market_exploration.md
+++ b/src/assets/help/tools_market_exploration.md
@@ -1,0 +1,3 @@
+Needs to be written.
+
+Needs to mention cleanups happening on data spikes and same-volume days

--- a/src/features/navigation/components/NavigationBar.vue
+++ b/src/features/navigation/components/NavigationBar.vue
@@ -191,11 +191,11 @@
 							display: userStore.hasFIO,
 							routerLink: "/fio/repair",
 						},
-						{
-							label: "Plan Import",
-							display: userStore.hasFIO,
-							routerLink: "/not-implemented",
-						},
+						// {
+						// 	label: "Plan Import",
+						// 	display: userStore.hasFIO,
+						// 	routerLink: "/not-implemented",
+						// },
 					],
 				},
 			],
@@ -217,9 +217,9 @@
 					icon: PersonSharp,
 				},
 				{
-					label: "Help",
+					label: "Help & Changelog",
 					display: true,
-					routerLink: "/not-implemented",
+					routerLink: "/help",
 					icon: HelpOutlineSharp,
 				},
 				{

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -109,6 +109,11 @@ const router = createRouter({
 			path: "/imprint-tos",
 			component: () => import("@/views/ImprintToSView.vue"),
 		},
+		{
+			name: "help",
+			path: "/help",
+			component: () => import("@/views/HelpView.vue"),
+		},
 	],
 });
 

--- a/src/views/EmpireView.vue
+++ b/src/views/EmpireView.vue
@@ -25,6 +25,7 @@
 	import RenderingProgress from "@/layout/components/RenderingProgress.vue";
 	import WrapperPlanningDataLoader from "@/features/wrapper/components/WrapperPlanningDataLoader.vue";
 	import WrapperGameDataLoader from "@/features/wrapper/components/WrapperGameDataLoader.vue";
+	import HelpDrawer from "@/features/help/components/HelpDrawer.vue";
 
 	const AsyncEmpirePlanList = defineAsyncComponent(
 		() => import("@/features/empire/components/EmpirePlanList.vue")
@@ -275,6 +276,7 @@
 							<h1 class="text-2xl font-bold my-auto">
 								{{ empireName }}
 							</h1>
+							<HelpDrawer file-name="empire" />
 						</div>
 
 						<div

--- a/src/views/HelpView.vue
+++ b/src/views/HelpView.vue
@@ -1,0 +1,48 @@
+<script setup lang="ts">
+	import { onMounted, Ref, ref } from "vue";
+
+	import { VueShowdown } from "vue-showdown";
+
+	// markdown loader from changelog
+	async function loadMarkdown(): Promise<string> {
+		const markdownFiles = import.meta.glob("@/assets/help/*.md", {
+			query: "?raw",
+			import: "default",
+		}) as Record<string, () => Promise<string>>;
+
+		const path = `/src/assets/help/changelog.md`;
+		const loader = markdownFiles[path];
+		if (!loader) throw new Error(`Markdown file "changelog" not found.`);
+
+		console.log(markdownFiles);
+
+		return await loader();
+	}
+
+	const markdownContent: Ref<string> = ref("");
+
+	onMounted(async () => (markdownContent.value = await loadMarkdown()));
+</script>
+
+<template>
+	<div class="min-h-screen flex flex-col">
+		<div
+			class="px-6 py-3 border-b border-white/10 flex flex-row justify-between">
+			<h1 class="text-2xl font-bold my-auto">Help & Changelog</h1>
+		</div>
+
+		<div
+			class="flex-grow grid grid-cols-1 lg:grid-cols-[60%_auto] gap-3 divide-x divide-white/10 child:px-6 child:py-3">
+			<div>
+				<h2 class="text-xl font-bold pb-3">Help</h2>
+				To be written...
+			</div>
+			<div>
+				<h2 class="text-xl font-bold pb-3">Changelog</h2>
+				<div v-if="markdownContent != ''" id="markdown">
+					<VueShowdown :markdown="markdownContent" />
+				</div>
+			</div>
+		</div>
+	</div>
+</template>

--- a/src/views/ImprintToSView.vue
+++ b/src/views/ImprintToSView.vue
@@ -1,4 +1,4 @@
-<script lang="ts"></script>
+<script setup lang="ts"></script>
 
 <template>
 	<div class="px-6 py-3">

--- a/src/views/tools/HQUpgradeCalculatorView.vue
+++ b/src/views/tools/HQUpgradeCalculatorView.vue
@@ -7,6 +7,7 @@
 	// Components
 	import WrapperGameDataLoader from "@/features/wrapper/components/WrapperGameDataLoader.vue";
 	import WrapperPlanningDataLoader from "@/features/wrapper/components/WrapperPlanningDataLoader.vue";
+	import HelpDrawer from "@/features/help/components/HelpDrawer.vue";
 	import CXPreferenceSelector from "@/features/exchanges/components/CXPreferenceSelector.vue";
 	import XITTransferActionButton from "@/features/xit/components/XITTransferActionButton.vue";
 	import MaterialTile from "@/features/material_tile/components/MaterialTile.vue";
@@ -58,6 +59,7 @@
 					<h1 class="text-2xl font-bold my-auto">
 						HQ Upgrade Calculator
 					</h1>
+					<HelpDrawer file-name="tools_hq_upgrade_calculator" />
 				</div>
 				<div
 					class="border-b border-white/10 grid grid-cols-1 xl:grid-cols-2 divide-x divide-white/10">

--- a/src/views/tools/market-data/MarketExplorationView.vue
+++ b/src/views/tools/market-data/MarketExplorationView.vue
@@ -6,6 +6,7 @@
 
 	// Components
 	import WrapperGameDataLoader from "@/features/wrapper/components/WrapperGameDataLoader.vue";
+	import HelpDrawer from "@/features/help/components/HelpDrawer.vue";
 
 	// Composables
 	import { useMarketExplorationChart } from "@/features/market_exploration/useMarketExplorationChart";
@@ -76,6 +77,7 @@
 							@click="fetchData">
 							Explore
 						</n-button>
+						<HelpDrawer file-name="tools_market_exploration" />
 					</div>
 				</div>
 			</div>


### PR DESCRIPTION
Introduces a Help & Changelog page accessible from navigation, loads changelog from markdown. Adds HelpDrawer components to Empire, HQ Upgrade Calculator, and Market Exploration views, with placeholder help markdown files. Updates navigation bar and router to support new help route.