### PR TITLE
Fix recipe profit calculations to use efficiency

### DIFF
--- a/src/assets/help/changelog.md
+++ b/src/assets/help/changelog.md
@@ -1,4 +1,8 @@
-# 2028-08-12
+# 2025-08-13
+
+- Fixed an issue where production building recipe selection did not take into account the buildings efficiency on revenue / day and roi metrics (by `lilbit-prun`)
+
+# 2025-08-12
 
 - Implement ROI Overview for production buildings and their recipes [#129](https://github.com/PRUNplanner/frontend/issues/129), enhance COGM with total profits and visitation frequency calculations
 - Add style for material `HBC`

--- a/src/features/planning/usePlanCalculation.ts
+++ b/src/features/planning/usePlanCalculation.ts
@@ -464,7 +464,7 @@ export function usePlanCalculation(
 					 * 	- Building Daily Workforce Cost (lux1 + lux2)
 					 */
 
-					const maxDailyRuns: number = TOTALMSDAY / br.TimeMs;
+					const maxDailyRuns: number = TOTALMSDAY / (br.TimeMs / totalEfficiency);
 
 					const dailyRevenue: number =
 						dailyIncome * maxDailyRuns -


### PR DESCRIPTION
I noticed this when the numbers felt unbelievable and verified against v1.

Before. The main thing to notice is I have 21 BMPs and PE has a $/Day of 1k, but the base has a profit of $63k. The base profit should be # of BMPs * profit of the recipe:
<img width="659" height="332" alt="Screenshot 2025-08-12 at 4 13 43 PM" src="https://github.com/user-attachments/assets/88eb49f7-bc49-4dc3-8770-8d73db62206f" />

After:
<img width="659" height="340" alt="Screenshot 2025-08-12 at 4 12 53 PM" src="https://github.com/user-attachments/assets/b5db5a63-45ba-478b-a849-c942b85d4b52" />

v1:
<img width="561" height="73" alt="Screenshot 2025-08-12 at 4 15 30 PM" src="https://github.com/user-attachments/assets/9360b3e6-d874-47cb-8529-6499c965840d" />
