### PR TITLE
fix(plan): tool re-rendering

### DIFF
--- a/src/assets/help/changelog.md
+++ b/src/assets/help/changelog.md
@@ -3,6 +3,7 @@
 - Fixed an issue where production building recipe selection did not take into account the buildings efficiency on revenue / day and roi metrics (by `lilbit-prun`)
 - Add "Buy From CX" option for XIT Actions for FIO Burn (by `lilbit-prun`)
 - Implement Resource ROI Overview [#130](https://github.com/PRUNplanner/frontend/issues/130)
+- Fix a bug where plan changes would automatically retrigger habitation optimization calls to the backend [#157](https://github.com/PRUNplanner/frontend/issues/157)
 
 # 2025-08-12
 

--- a/src/features/planning/components/tools/PlanOptimizeHabitation.vue
+++ b/src/features/planning/components/tools/PlanOptimizeHabitation.vue
@@ -1,5 +1,13 @@
 <script setup lang="ts">
-	import { computed, ComputedRef, PropType, Ref, ref, watch } from "vue";
+	import {
+		computed,
+		ComputedRef,
+		onMounted,
+		PropType,
+		Ref,
+		ref,
+		watch,
+	} from "vue";
 
 	// Composables
 	import { useQuery } from "@/lib/query_cache/useQuery";
@@ -72,6 +80,15 @@
 		}
 	);
 
+	const payloadChanged: Ref<boolean> = ref(false);
+
+	watch(
+		() => optimizePayload.value,
+		() => {
+			payloadChanged.value = true;
+		}
+	);
+
 	const habitationBuildings: string[] = [
 		"HB1",
 		"HB2",
@@ -109,24 +126,29 @@
 				console.error(error);
 				hasError.value = true;
 			})
-			.finally(() => (isLoading.value = false));
+			.finally(() => {
+				payloadChanged.value = false;
+				isLoading.value = false;
+			});
 	}
 
-	watch(
-		() => optimizePayload.value,
-		(newPayload) => {
-			fetchData(newPayload);
-		},
-		{ immediate: true }
-	);
+	onMounted(() => fetchData(optimizePayload.value));
 </script>
 
 <template>
 	<div class="pb-3 flex flex-row justify-between child:my-auto">
 		<h2 class="text-white/80 font-bold text-lg">Optimize Habitation</h2>
-		<n-button size="tiny" secondary @click="emit('close')">
-			<template #icon><CloseSharp /></template>
-		</n-button>
+		<div class="flex flex-row gap-3 child:!my-auto">
+			<n-button
+				size="small"
+				:disabled="!payloadChanged"
+				@click="fetchData(optimizePayload)">
+				Recalculate
+			</n-button>
+			<n-button size="tiny" secondary @click="emit('close')">
+				<template #icon><CloseSharp /></template>
+			</n-button>
+		</div>
 	</div>
 	<div>
 		<div v-if="totalWorkforce === 0" class="text-center pb-3 text-negative">


### PR DESCRIPTION
Refactored PlanView.vue to separate tool component loading logic from props, preventing unnecessary re-renders on prop changes. In PlanOptimizeHabitation.vue, added a 'Recalculate' button that is enabled when the payload changes, improving user control over recalculation and UI responsiveness.

fix #157