### PR TITLE
Making the setting of buy from cx sticky

### DIFF
--- a/src/features/empire/components/EmpirePlanList.vue
+++ b/src/features/empire/components/EmpirePlanList.vue
@@ -86,14 +86,14 @@
 					<router-link
 						to="/manage"
 						class="text-link-primary hover:underline">
-						Management</router-link
-					>
+						Management
+					</router-link>
 					or use
 					<router-link
 						to="/search"
 						class="text-link-primary hover:underline">
-						Planet Search</router-link
-					>
+						Planet Search
+					</router-link>
 					to create one.
 				</div>
 			</div>

--- a/src/features/manage/components/ManagePlanEmpireAssignments.vue
+++ b/src/features/manage/components/ManagePlanEmpireAssignments.vue
@@ -327,8 +327,8 @@
 					<router-link
 						to="/search"
 						class="text-link-primary hover:underline">
-						Planet Search</router-link
-					>
+						Planet Search
+					</router-link>
 					to create your first plan.
 				</div>
 			</div>

--- a/src/features/preferences/usePreferences.ts
+++ b/src/features/preferences/usePreferences.ts
@@ -56,6 +56,21 @@ export function usePreferences() {
 	});
 
 	/**
+	 * Writable computed for the users default "Buy Items From CX" setting
+	 *
+	 * @author lilbit
+	 *
+	 * @type {WritableComputedRef<boolean, boolean>}
+	 */
+	const defaultBuyItemsFromCX: WritableComputedRef<
+		boolean,
+		boolean
+	> = computed<boolean>({
+		get: () => userStore.preferences.defaultBuyItemsFromCX ?? true,
+		set: (v) => userStore.setPreference("defaultBuyItemsFromCX", v),
+	});
+
+	/**
 	 * Writable computed for the users RED alert on burn views
 	 *
 	 * @author jplacht
@@ -224,6 +239,7 @@ export function usePreferences() {
 	return {
 		// preferences
 		defaultCXUuid,
+		defaultBuyItemsFromCX,
 		defaultEmpireUuid,
 		burnDaysRed,
 		burnDaysYellow,

--- a/src/features/preferences/userDefaults.ts
+++ b/src/features/preferences/userDefaults.ts
@@ -11,6 +11,7 @@ import { IPreferenceDefault } from "@/features/preferences/userPreferences.types
 export const preferenceDefaults: IPreferenceDefault = {
 	defaultEmpireUuid: undefined,
 	defaultCXUuid: undefined,
+	defaultBuyItemsFromCX: true,
 	burnDaysRed: 5,
 	burnDaysYellow: 10,
 	burnResupplyDays: 20,

--- a/src/features/preferences/userPreferences.types.ts
+++ b/src/features/preferences/userPreferences.types.ts
@@ -6,6 +6,7 @@ export interface IPreferencePerPlan {
 export interface IPreference {
 	defaultEmpireUuid: string | undefined;
 	defaultCXUuid: string | undefined;
+	defaultBuyItemsFromCX: boolean;
 	burnDaysRed: number;
 	burnDaysYellow: number;
 	burnResupplyDays: number;

--- a/src/features/xit/components/XITBurnActionButton.vue
+++ b/src/features/xit/components/XITBurnActionButton.vue
@@ -6,7 +6,7 @@
 	import { useXITAction } from "@/features/xit/useXITAction";
 	import { usePreferences } from "@/features/preferences/usePreferences";
 
-	const { burnResupplyDays, burnOrigin, getBurnDisplayClass } =
+	const { burnResupplyDays, burnOrigin, getBurnDisplayClass, defaultBuyItemsFromCX } =
 		usePreferences();
 	const { transferJSON } = useXITAction();
 
@@ -74,7 +74,6 @@
 	// Drawer Display
 	const loadDrawer: Ref<boolean> = ref(false);
 	const showDrawer: Ref<boolean> = ref(false);
-	const xitBuyFromCX = ref(true);
 
 	function show(): void {
 		if (!showDrawer.value) {
@@ -136,7 +135,7 @@
 							</p>
 							<n-checkbox
 								v-else
-								v-model:checked="xitBuyFromCX"
+								v-model:checked="defaultBuyItemsFromCX"
 								:disabled="
 									burnOrigin === 'Configure on Execution'
 								" />
@@ -166,7 +165,7 @@
 								{
 									name: 'Burn Supply',
 									origin: burnOrigin,
-									buy: xitBuyFromCX,
+									buy: defaultBuyItemsFromCX,
 								}
 							).value
 						"
@@ -193,7 +192,7 @@
 									{
 										name: 'Burn Supply',
 										origin: burnOrigin,
-										buy: xitBuyFromCX,
+										buy: defaultBuyItemsFromCX,
 									}
 								).value
 							)

--- a/src/features/xit/components/XITTransferActionButton.vue
+++ b/src/features/xit/components/XITTransferActionButton.vue
@@ -5,7 +5,7 @@
 	import { useXITAction } from "@/features/xit/useXITAction";
 	const { transferJSON } = useXITAction();
 	import { usePreferences } from "@/features/preferences/usePreferences";
-	const { burnOrigin } = usePreferences();
+	const { burnOrigin, defaultBuyItemsFromCX } = usePreferences();
 
 	// Components
 	import MaterialTile from "@/features/material_tile/components/MaterialTile.vue";
@@ -70,7 +70,6 @@
 	// Drawer Display
 	const loadDrawer: Ref<boolean> = ref(false);
 	const showDrawer: Ref<boolean> = ref(false);
-	const xitBuyFromCX: Ref<boolean> = ref(true);
 
 	function show(): void {
 		if (!showDrawer.value) {
@@ -101,7 +100,7 @@
 				</n-form-item>
 				<n-form-item label="Buy Items From CX">
 					<n-checkbox
-						v-model:checked="xitBuyFromCX"
+						v-model:checked="defaultBuyItemsFromCX"
 						:disabled="burnOrigin === 'Configure on Execution'" />
 
 					<p
@@ -116,7 +115,7 @@
 							transferJSON(elements, {
 								name: 'Supply',
 								origin: burnOrigin,
-								buy: xitBuyFromCX,
+								buy: defaultBuyItemsFromCX,
 							}).value
 						"
 						size="small"
@@ -129,7 +128,7 @@
 								transferJSON(elements, {
 									name: 'Supply',
 									origin: burnOrigin,
-									buy: xitBuyFromCX,
+									buy: defaultBuyItemsFromCX,
 								}).value
 							)
 						">


### PR DESCRIPTION
This was requested by lowstrife in discord. Now if you uncheck buy from cx, it will remember that when showing you that view in the future.