### PR TITLE
fix(management): checkbox performance

### DIFF
--- a/src/features/manage/components/ManagePlanEmpireAssignments.vue
+++ b/src/features/manage/components/ManagePlanEmpireAssignments.vue
@@ -30,9 +30,10 @@
 	// Components
 	import SharingButton from "@/features/sharing/components/SharingButton.vue";
 	import ManageAssignmentFilters from "@/features/manage/components/ManageAssignmentFilters.vue";
+	import SimpleCheckbox from "@/layout/components/SimpleCheckbox.vue";
 
 	// UI
-	import { useDialog, NCheckbox, NButton, NIcon } from "naive-ui";
+	import { useDialog, NButton, NIcon } from "naive-ui";
 	const dialog = useDialog();
 	import { XNDataTable, XNDataTableColumn } from "@skit/x.naive-ui";
 	import {
@@ -373,9 +374,8 @@
 					</div>
 				</template>
 				<template #render-cell="{ rowData }">
-					<div class="text-center">
-						<n-checkbox
-							:key="`CHECKBOX#${e.empireUuid}#${rowData.planUuid}`"
+					<div class="flex flex-col items-center">
+						<SimpleCheckbox
 							v-model:checked="rowData.empires[e.empireUuid]" />
 					</div>
 				</template>

--- a/src/layout/components/SimpleCheckbox.vue
+++ b/src/layout/components/SimpleCheckbox.vue
@@ -1,0 +1,30 @@
+<script setup lang="ts">
+	// Naive-UI Checkbox kills performance if it is rendered hundreds of times. This is lightweight.
+	const checked = defineModel<boolean>("checked");
+</script>
+
+<template>
+	<div class="inline-flex items-center">
+		<label class="flex items-center cursor-pointer relative">
+			<input
+				v-model="checked"
+				type="checkbox"
+				class="peer h-4 w-4 cursor-pointer transition-all appearance-none rounded shadow hover:shadow-md border border-table-border checked:bg-[#2a61bd] checked:border-[#2a61bd]" />
+			<span
+				class="absolute text-white opacity-0 peer-checked:opacity-100 top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2">
+				<svg
+					xmlns="http://www.w3.org/2000/svg"
+					class="h-3.5 w-3.5"
+					viewBox="0 0 20 20"
+					fill="currentColor"
+					stroke="currentColor"
+					stroke-width="1">
+					<path
+						fill-rule="evenodd"
+						d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z"
+						clip-rule="evenodd"></path>
+				</svg>
+			</span>
+		</label>
+	</div>
+</template>


### PR DESCRIPTION
Taiyi discovered that on 100+ plans + 10+ empires the ManagementView becomes extremely slow to render. The Naive-UI Checkbox component is at fault of most of the time spike. Replacing it with a lightweight own Checkbox component.