### PR TITLE
feat(query): populate cache from list results

### DIFF
--- a/src/lib/query_cache/queryRepository.ts
+++ b/src/lib/query_cache/queryRepository.ts
@@ -188,6 +188,17 @@ export function useQueryRepository() {
 						params.planetNaturalIds
 					);
 					gameDataStore.setMultiplePlanets(data);
+
+					// set plans individually
+					data.forEach((p) => {
+						queryStore.addCacheState(
+							["gamedata", "planet", p.PlanetNaturalId],
+							queryRepository.GetPlanet,
+							{ planetNaturalId: p.PlanetNaturalId },
+							p
+						);
+					});
+
 					return data;
 				} catch {
 					return [];
@@ -369,6 +380,17 @@ export function useQueryRepository() {
 				try {
 					const data = await callGetEmpirePlans(params.empireUuid);
 					planningStore.setPlans(data);
+
+					// manually set individual plans
+					data.forEach((p) =>
+						queryStore.addCacheState(
+							["planningdata", "plan", p.uuid],
+							queryRepository.GetPlan,
+							{ planUuid: p.uuid! },
+							p
+						)
+					);
+
 					return data;
 				} catch {
 					return [];
@@ -485,6 +507,17 @@ export function useQueryRepository() {
 				try {
 					const data = await callGetPlanlist();
 					planningStore.setPlans(data);
+
+					// manually set individual plans
+					data.forEach((p) =>
+						queryStore.addCacheState(
+							["planningdata", "plan", p.uuid],
+							queryRepository.GetPlan,
+							{ planUuid: p.uuid! },
+							p
+						)
+					);
+
 					return data;
 				} catch {
 					return [];

--- a/src/lib/query_cache/queryStore.ts
+++ b/src/lib/query_cache/queryStore.ts
@@ -266,6 +266,47 @@ export const useQueryStore = defineStore("prunplanner_query_store", () => {
 	}
 
 	/**
+	 * Allows manually creating a cache state
+	 *
+	 * @author jplacht
+	 *
+	 * @async
+	 * @template TParams Params
+	 * @template TData Data
+	 * @param {JSONValue} key Key Value
+	 * @param {QueryDefinition<TParams, TData>} definition Query Definition
+	 * @param {TParams} params Query Params
+	 * @param {TData} data Result Data
+	 * @returns {Promise<void>} void
+	 */
+	async function addCacheState<TParams, TData>(
+		key: JSONValue,
+		definition: QueryDefinition<TParams, TData>,
+		params: TParams,
+		data: TData
+	): Promise<void> {
+		const keyHash: string = toCacheKey(key);
+
+		// do not overwrite existing state for key
+		if (!cache.get(keyHash)) {
+			cache.set(keyHash, {
+				definition: null,
+				params: null,
+				data: data,
+				loading: false,
+				error: null,
+				timestamp: Date.now(),
+				expireTime: undefined,
+			});
+
+			const state = cache.get(keyHash)! as QueryState<TParams, TData>;
+			state.definition = definition;
+			state.params = params;
+			state.expireTime = definition.expireTime;
+		}
+	}
+
+	/**
 	 * True, if any cache state is currently loading
 	 * @author jplacht
 	 *
@@ -332,6 +373,7 @@ export const useQueryStore = defineStore("prunplanner_query_store", () => {
 		peekQueryState,
 		executeQuery,
 		invalidateKey,
+		addCacheState,
 		isAnythingLoading,
 		// only exposed for testing
 		checkEntryStatusAndRefresh,


### PR DESCRIPTION
Populates query results for planets and plans from lists (like allplans, empire plans or planet multiple) into per entry cache keys manually to prevent additional loading afterwards.