### PR TITLE
fix(materialtile): proper keys for DOM updates

### DIFF
--- a/src/assets/help/changelog.md
+++ b/src/assets/help/changelog.md
@@ -1,6 +1,7 @@
 # 2025-08-21
 
 - Reenables moduleSideEffect treeshaking to properly have Highcharts render Stockcharts [#190](https://github.com/PRUNplanner/frontend/issues/190)
+- Fixes the issue where Exchange information on Material Tiles did not get properly updated in the DOM
 
 # 2025-08-20
 

--- a/src/features/material_tile/components/MaterialTile.vue
+++ b/src/features/material_tile/components/MaterialTile.vue
@@ -147,7 +147,7 @@
 </script>
 
 <template>
-	<div class="inline-block">
+	<div class="inline-block" :class="`material-tile#${ticker}`">
 		<div
 			class="flex flex-row items-center justify-center w-full material-tile"
 			:class="[
@@ -170,6 +170,7 @@
 				</template>
 				<MaterialCXOverviewTable
 					v-if="refExchangeOverview"
+					:key="`material-tile#CXOverview#${ticker}`"
 					:ticker="ticker"
 					:overview-data="refExchangeOverview" />
 			</PTooltip>
@@ -223,8 +224,8 @@
 			<div class="flex gap-x-5">
 				<div class="flex items-center">
 					<div
-						:class="`Material-${ticker}`"
-						class="text-nowrap p-2 px-4 text-2xl">
+						:class="categoryCssClass"
+						class="text-nowrap p-2 px-4 text-2xl text-shadow-[0_1px_1px_rgb(34,34,34)]">
 						{{ getMaterial(ticker).Ticker }}
 					</div>
 				</div>

--- a/src/features/planning/components/PlanMaterialIO.vue
+++ b/src/features/planning/components/PlanMaterialIO.vue
@@ -38,6 +38,7 @@
 		<XNDataTableColumn key="ticker" title="Ticker" sorter="default">
 			<template #render-cell="{ rowData }">
 				<MaterialTile
+					:key="`MATERIALIO#MATERIALTILE#${rowData.ticker}`"
 					:ticker="rowData.ticker"
 					:disable-drawer="false" />
 			</template>


### PR DESCRIPTION
Adds unique :key bindings to MaterialTile and MaterialCXOverviewTable components to ensure proper DOM updates when exchange information changes. Also improves class binding for better style consistency.