### PR TITLE
refactor(tsc): typescheck config, build without tsc

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,9 +5,9 @@
 	"type": "module",
 	"scripts": {
 		"dev": "vite",
-		"build": "vue-tsc --noEmit && vite build && node scripts/write-version.js",
-		"tsc": "vue-tsc --project tsconfig.app.json",
-		"tsc:watch": "vue-tsc --project tsconfig.app.json --watch",
+		"build": "vite build && node scripts/write-version.js",
+		"tsc": "vue-tsc --project tsconfig.typecheck.json",
+		"tsc:watch": "vue-tsc --project tsconfig.typecheck.json --watch",
 		"preview": "vite preview",
 		"test": "vitest --run --silent",
 		"test:ui": "vitest --ui",

--- a/scripts/write-version.js
+++ b/scripts/write-version.js
@@ -1,6 +1,7 @@
 /**
  * Small helper script executed on build to create
- * a version.json file containing the build date.
+ * a version.json file containing the build date
+ * or Netlify commit reference.
  *
  * @author jplacht
  */

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -11,7 +11,6 @@
 		"coverage/**/*",
 		".vscode/**/*",
 		".github/**/*",
-		"src/tests/**/*",
 	],
 	"compilerOptions": {
 		"target": "ESNext",

--- a/tsconfig.typecheck.json
+++ b/tsconfig.typecheck.json
@@ -1,0 +1,6 @@
+{
+	"extends": "./tsconfig.app.json",
+	"exclude": [
+		"src/tests/**/*",
+	]
+}


### PR DESCRIPTION
Moved test exclusion from tsconfig.app.json to a new tsconfig.typecheck.json for type checking scripts. Updated package.json scripts to use the new config. Improved write-version.js comment for clarity.