### PR TITLE
HQUpgrade should not count starting level materials

### DIFF
--- a/src/features/hq_upgrade_calculator/useHQUpgradeCalculator.ts
+++ b/src/features/hq_upgrade_calculator/useHQUpgradeCalculator.ts
@@ -76,8 +76,9 @@ export function useHQUpgradeCalculator(
 
 		if (hasError.value) return [];
 
-		// iterate over all upgrade costs from "start" to "to" values
-		for (let index = start.value; index <= to.value; index++) {
+		// iterate over all upgrade costs from "start" to "to" 
+		// do not count the materials for the start value (+1)
+		for (let index = start.value + 1; index <= to.value; index++) {
 			const element = data[index];
 
 			// check and create or add to sumData


### PR DESCRIPTION
Don't include the materials for the start level in the HQ calculation

**Local dev with change**
<img width="1350" height="478" alt="image" src="https://github.com/user-attachments/assets/71d67ff1-7e96-478b-9a30-58207e1fb9b1" />

**Live preview**
<img width="1370" height="735" alt="image" src="https://github.com/user-attachments/assets/8c8b1acb-e6a4-415b-8534-27ba39d7e43d" />
