### PR TITLE
Key-based Backend Communcation, Store persistance & cross-tab broadcasting

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -36,6 +36,17 @@ export default [
 				{ allowTernary: true },
 			],
 			"no-async-promise-executor": "off",
+
+			// ensure underscore-prefixed names are ignored for unused-vars
+			"no-unused-vars": "off", // disable base rule
+			"@typescript-eslint/no-unused-vars": [
+				"warn",
+				{
+					varsIgnorePattern: "^_",
+					argsIgnorePattern: "^_",
+					caughtErrorsIgnorePattern: "^_",
+				},
+			],
 		},
 	},
 

--- a/src/assets/help/changelog.md
+++ b/src/assets/help/changelog.md
@@ -1,3 +1,12 @@
+# 2025-08-24
+
+- The backend communication layer has been restructured to be key-based rather than using direct function calls, improving handling and enabling more predictable state management.
+- Added functionality to persist Query, Game, and Planning data so that users’ data state is maintained across browser sessions. Additionally, static data is now broadcasted across all open tabs in the same browser.
+
+# 2025-08-23
+
+- Fixes an issue in HQ Upgrade Calculations were the starting level was wrongly part of the material list (by `skiedude`)
+
 # 2025-08-22
 
 - Fixes a bug where Planet Search material results were not sortable. This also identified a potential backend issue where searching for more than 2 materials returns results that actually don't hold the materials searched for. Currently the frontend limits to search for maximum of 2 resources until the API handling of the search query was investigated and potentially fixed.

--- a/src/features/account/components/VerifyEmailComponent.vue
+++ b/src/features/account/components/VerifyEmailComponent.vue
@@ -2,7 +2,6 @@
 	import { computed, ComputedRef, ref, Ref } from "vue";
 
 	// API
-	import { useQueryRepository } from "@/lib/query_cache/queryRepository";
 	import { useQuery } from "@/lib/query_cache/useQuery";
 
 	// Composables
@@ -28,13 +27,12 @@
 	async function verifyEmail(): Promise<void> {
 		isVerifying.value = true;
 
-		await useQuery(useQueryRepository().repository.PostUserVerifyEmail, {
+		await useQuery("PostUserVerifyEmail", {
 			code: refVerificationCode.value,
 		})
 			.execute()
 			.then((result: boolean) => {
 				verifyStatus.value = result;
-
 				capture("user_verify_email", { status: result });
 			})
 			.finally(() => {

--- a/src/features/empire/components/EmpireConfiguration.vue
+++ b/src/features/empire/components/EmpireConfiguration.vue
@@ -3,7 +3,6 @@
 
 	// Composables
 	import { useQuery } from "@/lib/query_cache/useQuery";
-	import { useQueryRepository } from "@/lib/query_cache/queryRepository";
 	import { usePostHog } from "@/lib/usePostHog";
 	const { capture } = usePostHog();
 
@@ -93,7 +92,7 @@
 		};
 
 		try {
-			await useQuery(useQueryRepository().repository.PatchEmpire, {
+			await useQuery("PatchEmpire", {
 				empireUuid: localData.value.uuid,
 				data: patchData,
 			}).execute();

--- a/src/features/government/components/PlanetPOPRButton.vue
+++ b/src/features/government/components/PlanetPOPRButton.vue
@@ -3,7 +3,6 @@
 
 	// Composables
 	import { useQuery } from "@/lib/query_cache/useQuery";
-	import { useQueryRepository } from "@/lib/query_cache/queryRepository";
 	import { usePostHog } from "@/lib/usePostHog";
 	const { capture } = usePostHog();
 
@@ -44,7 +43,7 @@
 		capture("popr_load", { planetId: planetNaturalId });
 
 		try {
-			await useQuery(useQueryRepository().repository.GetPlanetLastPOPR, {
+			await useQuery("GetPlanetLastPOPR", {
 				planetNaturalId: planetNaturalId,
 			})
 				.execute()

--- a/src/features/manage/components/ManageCX.vue
+++ b/src/features/manage/components/ManageCX.vue
@@ -2,7 +2,6 @@
 	import { computed, ComputedRef, PropType, ref, Ref } from "vue";
 
 	// Composables
-	import { useQueryRepository } from "@/lib/query_cache/queryRepository";
 	import { useQuery } from "@/lib/query_cache/useQuery";
 	import { usePostHog } from "@/lib/usePostHog";
 	const { capture } = usePostHog();
@@ -55,17 +54,12 @@
 
 			capture("manage_cx_create");
 
-			await useQuery(useQueryRepository().repository.CreateCX, {
+			await useQuery("CreateCX", {
 				cxName: refNewCXName.value!,
 			}).execute();
 
 			// forced reload of all CX
-			emit(
-				"update:cxList",
-				await useQuery(
-					useQueryRepository().repository.GetAllCX
-				).execute()
-			);
+			emit("update:cxList", await useQuery("GetAllCX").execute());
 
 			refNewCXName.value = "";
 			refShowCreateCX.value = false;
@@ -91,19 +85,13 @@
 
 		capture("manage_cx_delete", { cxUuid: cxUuid });
 
-		const deletionResult: boolean = await useQuery(
-			useQueryRepository().repository.DeleteCX,
-			{ cxUuid: cxUuid }
-		).execute();
+		const deletionResult: boolean = await useQuery("DeleteCX", {
+			cxUuid: cxUuid,
+		}).execute();
 
 		if (deletionResult) {
 			// forced reload of all CX
-			emit(
-				"update:cxList",
-				await useQuery(
-					useQueryRepository().repository.GetAllCX
-				).execute()
-			);
+			emit("update:cxList", await useQuery("GetAllCX").execute());
 		}
 
 		refIsDeleting.value = undefined;

--- a/src/features/manage/components/ManageEmpire.vue
+++ b/src/features/manage/components/ManageEmpire.vue
@@ -3,7 +3,6 @@
 
 	// Composables
 	import { useQuery } from "@/lib/query_cache/useQuery";
-	import { useQueryRepository } from "@/lib/query_cache/queryRepository";
 	import { usePostHog } from "@/lib/usePostHog";
 	const { capture } = usePostHog();
 
@@ -166,19 +165,11 @@
 		try {
 			capture("manage_empire_junctions_update");
 
-			await useQuery(
-				useQueryRepository().repository.PatchEmpireCXJunctions,
-				{
-					junctions: cxEmpireJunctions.value,
-				}
-			).execute();
+			await useQuery("PatchEmpireCXJunctions", {
+				junctions: cxEmpireJunctions.value,
+			}).execute();
 
-			emit(
-				"update:cxList",
-				await useQuery(
-					useQueryRepository().repository.GetAllCX
-				).execute()
-			);
+			emit("update:cxList", await useQuery("GetAllCX").execute());
 			refCreateName.value = "";
 		} catch (err) {
 			console.error(err);
@@ -194,7 +185,7 @@
 			if (compCanCreate.value) {
 				capture("manage_empire_create");
 
-				await useQuery(useQueryRepository().repository.CreateEmpire, {
+				await useQuery("CreateEmpire", {
 					data: {
 						faction: refCreateFaction.value,
 						permits_used: refCreatePermitsUsed.value,
@@ -207,9 +198,7 @@
 				// forced reload of all Empires
 				emit(
 					"update:empireList",
-					await useQuery(
-						useQueryRepository().repository.GetAllEmpires
-					).execute()
+					await useQuery("GetAllEmpires").execute()
 				);
 			}
 		} catch (err) {
@@ -236,18 +225,15 @@
 	async function deleteEmpire(empireUuid: string): Promise<void> {
 		refIsDeleting.value = empireUuid;
 		capture("manage_empire_delete", { empireUuid: empireUuid });
-		const deletionResult: boolean = await useQuery(
-			useQueryRepository().repository.DeleteEmpire,
-			{ empireUuid: empireUuid }
-		).execute();
+		const deletionResult: boolean = await useQuery("DeleteEmpire", {
+			empireUuid: empireUuid,
+		}).execute();
 
 		if (deletionResult) {
 			// forced reload of all Empires
 			emit(
 				"update:empireList",
-				await useQuery(
-					useQueryRepository().repository.GetAllEmpires
-				).execute()
+				await useQuery("GetAllEmpires").execute()
 			);
 		}
 

--- a/src/features/manage/components/ManagePlanEmpireAssignments.vue
+++ b/src/features/manage/components/ManagePlanEmpireAssignments.vue
@@ -13,7 +13,6 @@
 	import { usePlanetData } from "@/features/game_data/usePlanetData";
 	const { getPlanetName } = usePlanetData();
 	import { useQuery } from "@/lib/query_cache/useQuery";
-	import { useQueryRepository } from "@/lib/query_cache/queryRepository";
 	import { usePostHog } from "@/lib/usePostHog";
 	const { capture } = usePostHog();
 	// Util
@@ -215,13 +214,13 @@
 	);
 
 	async function updateEmitEmpiresPlans(): Promise<void> {
-		useQuery(useQueryRepository().repository.GetAllEmpires, undefined)
+		useQuery("GetAllEmpires")
 			.execute()
 			.then((e: IPlanEmpireElement[]) => {
 				emit("update:empireList", e);
 			});
 
-		useQuery(useQueryRepository().repository.GetAllPlans, undefined)
+		useQuery("GetAllPlans")
 			.execute()
 			.then((p: IPlan[]) => emit("update:planList", p));
 	}
@@ -231,7 +230,7 @@
 
 		capture("manage_plans_junctions_update");
 
-		useQuery(useQueryRepository().repository.PatchEmpirePlanJunctions, {
+		useQuery("PatchEmpirePlanJunctions", {
 			junctions: patchJunctionData.value,
 		})
 			.execute()
@@ -247,7 +246,7 @@
 
 		capture("manage_plans_clone", { planUuid: planUuid });
 
-		useQuery(useQueryRepository().repository.ClonePlan, {
+		useQuery("ClonePlan", {
 			planUuid: planUuid,
 			cloneName: `${planName} (Clone)`,
 		})
@@ -275,7 +274,7 @@
 
 		capture("manage_plans_delete", { planUuid: planUuid });
 
-		useQuery(useQueryRepository().repository.DeletePlan, {
+		useQuery("DeletePlan", {
 			planUuid: planUuid,
 		})
 			.execute()

--- a/src/features/market_exploration/useMarketExploration.ts
+++ b/src/features/market_exploration/useMarketExploration.ts
@@ -1,6 +1,5 @@
 // Composables
 import { useQuery } from "@/lib/query_cache/useQuery";
-import { useQueryRepository } from "@/lib/query_cache/queryRepository";
 
 // Util
 import { formatDate } from "@/util/date";
@@ -49,7 +48,7 @@ export function useMarketExploration() {
 			"IC1",
 			"NC1",
 		].map((exchangeTicker) =>
-			useQuery(useQueryRepository().repository.GetExplorationData, {
+			useQuery("GetExplorationData", {
 				exchangeTicker: exchangeTicker,
 				materialTicker: ticker,
 				payload: fetchPayload,

--- a/src/features/market_exploration/useMarketExplorationChart.ts
+++ b/src/features/market_exploration/useMarketExplorationChart.ts
@@ -5,7 +5,6 @@ import dayjs from "dayjs";
 import { formatDate } from "@/util/date";
 
 // Composables
-import { useQueryRepository } from "@/lib/query_cache/queryRepository";
 import { useQuery } from "@/lib/query_cache/useQuery";
 
 // Types & Interfaces
@@ -132,7 +131,7 @@ export function useMarketExplorationChart(
 		error.value = false;
 		data.value = [];
 
-		await useQuery(useQueryRepository().repository.GetExplorationData, {
+		await useQuery("GetExplorationData", {
 			exchangeTicker: exchangeTicker.value,
 			materialTicker: materialTicker.value,
 			payload: {

--- a/src/features/navigation/components/NavigationBar.vue
+++ b/src/features/navigation/components/NavigationBar.vue
@@ -7,7 +7,6 @@
 
 	// API
 	import { useQuery } from "@/lib/query_cache/useQuery";
-	import { useQueryRepository } from "@/lib/query_cache/queryRepository";
 
 	// Router
 	import router from "@/router";
@@ -49,10 +48,8 @@
 		() => userStore.hasFIO,
 		(newValue: boolean) => {
 			if (newValue) {
-				useQuery(
-					useQueryRepository().repository.GetFIOStorage
-				).execute();
-				useQuery(useQueryRepository().repository.GetFIOSites).execute();
+				useQuery("GetFIOStorage").execute();
+				useQuery("GetFIOSites").execute();
 			} else {
 				queryStore.invalidateKey(["gamedata", "fio"], {
 					exact: false,

--- a/src/features/planet_search/components/PlanetSearchAdvanced.vue
+++ b/src/features/planet_search/components/PlanetSearchAdvanced.vue
@@ -3,7 +3,6 @@
 
 	// API
 	import { useQuery } from "@/lib/query_cache/useQuery";
-	import { useQueryRepository } from "@/lib/query_cache/queryRepository";
 
 	// Composables
 	import { usePostHog } from "@/lib/usePostHog";
@@ -142,12 +141,9 @@
 		});
 
 		try {
-			const data: IPlanet[] = await useQuery(
-				useQueryRepository().repository.PostPlanetSearch,
-				{
-					searchData: searchPayload.value,
-				}
-			).execute();
+			const data: IPlanet[] = await useQuery("PostPlanetSearch", {
+				searchData: searchPayload.value,
+			}).execute();
 			emit("update:results", data);
 			emit("update:materials", inputMaterials.value);
 		} catch {

--- a/src/features/planet_search/components/PlanetSearchBasic.vue
+++ b/src/features/planet_search/components/PlanetSearchBasic.vue
@@ -3,7 +3,6 @@
 
 	// API
 	import { useQuery } from "@/lib/query_cache/useQuery";
-	import { useQueryRepository } from "@/lib/query_cache/queryRepository";
 
 	// Composables
 	import { usePostHog } from "@/lib/usePostHog";
@@ -34,12 +33,9 @@
 			capture("planet_search_basic");
 
 			try {
-				await useQuery(
-					useQueryRepository().repository.GetPlanetSearchSingle,
-					{
-						searchId: refSearchId.value!,
-					}
-				)
+				await useQuery("GetPlanetSearchSingle", {
+					searchId: refSearchId.value!,
+				})
 					.execute()
 					.then((data: IPlanet[]) => emit("update:results", data))
 					.finally(() => (isLoading.value = false));

--- a/src/features/planning/components/tools/PlanOptimizeHabitation.vue
+++ b/src/features/planning/components/tools/PlanOptimizeHabitation.vue
@@ -11,7 +11,6 @@
 
 	// Composables
 	import { useQuery } from "@/lib/query_cache/useQuery";
-	import { useQueryRepository } from "@/lib/query_cache/queryRepository";
 
 	// Types & Interfaces
 	import {
@@ -115,10 +114,7 @@
 		// check so that there is a workforce requirement
 		if (totalWorkforce.value === 0) return;
 
-		await useQuery(
-			useQueryRepository().repository.OptimizeHabitation,
-			payload
-		)
+		await useQuery("OptimizeHabitation", payload)
 			.execute()
 			.then((result: IOptimizeHabitationResponse) => {
 				responseData.value = result;

--- a/src/features/planning/components/tools/PlanPOPR.vue
+++ b/src/features/planning/components/tools/PlanPOPR.vue
@@ -3,7 +3,6 @@
 
 	// Composables
 	import { useQuery } from "@/lib/query_cache/useQuery";
-	import { useQueryRepository } from "@/lib/query_cache/queryRepository";
 
 	// Components
 	import PlanetPOPRTable from "@/features/government/components/PlanetPOPRTable.vue";
@@ -35,7 +34,7 @@
 	async function fetchPOPR(planetNaturalId: string) {
 		isLoading.value = true;
 		try {
-			await useQuery(useQueryRepository().repository.GetPlanetLastPOPR, {
+			await useQuery("GetPlanetLastPOPR", {
 				planetNaturalId: planetNaturalId,
 			})
 				.execute()

--- a/src/features/planning_data/usePlan.ts
+++ b/src/features/planning_data/usePlan.ts
@@ -1,5 +1,4 @@
 import { useQuery } from "@/lib/query_cache/useQuery";
-import { useQueryRepository } from "@/lib/query_cache/queryRepository";
 
 import { usePlanningStore } from "@/stores/planningStore";
 
@@ -164,12 +163,12 @@ export function usePlan() {
 	): Promise<string | undefined> {
 		try {
 			const createdData: IPlanSaveCreateResponse = await useQuery(
-				useQueryRepository().repository.CreatePlan,
+				"CreatePlan",
 				{ data: data }
 			).execute();
 
 			// trigger backend data load
-			await useQuery(useQueryRepository().repository.GetPlan, {
+			await useQuery("GetPlan", {
 				planUuid: createdData.uuid,
 			});
 			return createdData.uuid;
@@ -195,7 +194,7 @@ export function usePlan() {
 	): Promise<string | undefined> {
 		try {
 			const savedData: IPlanSaveCreateResponse = await useQuery(
-				useQueryRepository().repository.PatchPlan,
+				"PatchPlan",
 				{
 					planUuid: planUuid,
 					data: {
@@ -206,7 +205,7 @@ export function usePlan() {
 			).execute();
 
 			if (savedData) {
-				await useQuery(useQueryRepository().repository.GetPlan, {
+				await useQuery("GetPlan", {
 					planUuid: savedData.uuid,
 				}).execute();
 				return savedData.uuid;
@@ -233,7 +232,7 @@ export function usePlan() {
 		planetNaturalId: string,
 		materialio: IMaterialIO[]
 	): Promise<boolean> {
-		return await useQuery(useQueryRepository().repository.PatchMaterialIO, {
+		return await useQuery("PatchMaterialIO", {
 			data: [
 				{
 					uuid: planUuid,

--- a/src/features/profile/components/ChangePassword.vue
+++ b/src/features/profile/components/ChangePassword.vue
@@ -3,7 +3,6 @@
 
 	// API
 	import { useQuery } from "@/lib/query_cache/useQuery";
-	import { useQueryRepository } from "@/lib/query_cache/queryRepository";
 
 	// Composables
 	import { usePostHog } from "@/lib/usePostHog";
@@ -35,13 +34,10 @@
 
 		capture("user_password_change");
 
-		await useQuery(
-			useQueryRepository().repository.PatchUserChangePassword,
-			{
-				old: refCurrentPassword.value,
-				new: refNewPassword.value,
-			}
-		)
+		await useQuery("PatchUserChangePassword", {
+			old: refCurrentPassword.value,
+			new: refNewPassword.value,
+		})
 			.execute()
 			.then((result: boolean) => {
 				changeStatus.value = result;

--- a/src/features/profile/components/ChangeProfile.vue
+++ b/src/features/profile/components/ChangeProfile.vue
@@ -3,7 +3,6 @@
 
 	// API
 	import { useQuery } from "@/lib/query_cache/useQuery";
-	import { useQueryRepository } from "@/lib/query_cache/queryRepository";
 
 	// Composables
 	import { usePostHog } from "@/lib/usePostHog";
@@ -44,7 +43,7 @@
 		isUpdating.value = true;
 
 		try {
-			await useQuery(useQueryRepository().repository.PatchUserProfile, {
+			await useQuery("PatchUserProfile", {
 				fio_apikey: localProfile.fio_apikey?.replace(/ /g, "") ?? null,
 				prun_username: localProfile.prun_username ?? null,
 				email: localProfile.email ?? null,
@@ -62,10 +61,7 @@
 		capture("user_request_email_verification");
 
 		try {
-			await useQuery(
-				useQueryRepository().repository.PostUserResendEmailVerification,
-				null
-			).execute();
+			await useQuery("PostUserResendEmailVerification", null).execute();
 		} catch (err) {
 			console.error("Error resending verification code", err);
 		} finally {

--- a/src/features/resource_roi_overview/useResourceROIOverview.ts
+++ b/src/features/resource_roi_overview/useResourceROIOverview.ts
@@ -2,7 +2,6 @@ import { ref, Ref } from "vue";
 
 // API
 import { useQuery } from "@/lib/query_cache/useQuery";
-import { useQueryRepository } from "@/lib/query_cache/queryRepository";
 
 // Composables
 import {
@@ -46,7 +45,7 @@ export function useResourceROIOverview(cxUuid: Ref<string | undefined>) {
 	);
 
 	async function searchPlanets(materialTicker: string): Promise<IPlanet[]> {
-		await useQuery(useQueryRepository().repository.PostPlanetSearch, {
+		await useQuery("PostPlanetSearch", {
 			searchData: {
 				Materials: [materialTicker],
 				COGC: [],

--- a/src/features/sharing/useSharing.ts
+++ b/src/features/sharing/useSharing.ts
@@ -2,7 +2,6 @@ import { computed, ComputedRef } from "vue";
 
 // API
 import { useQuery } from "@/lib/query_cache/useQuery";
-import { useQueryRepository } from "@/lib/query_cache/queryRepository";
 
 // Stores
 import { usePlanningStore } from "@/stores/planningStore";
@@ -57,7 +56,7 @@ export function useSharing(planUuid: string) {
 	 * @returns {Promise<void>}
 	 */
 	async function refreshStore(): Promise<void> {
-		await useQuery(useQueryRepository().repository.GetAllShared).execute();
+		await useQuery("GetAllShared").execute();
 	}
 
 	/**
@@ -74,7 +73,7 @@ export function useSharing(planUuid: string) {
 			// call share deletion
 
 			console.log("delete", planningStore.shared[planUuid].shared_uuid);
-			await useQuery(useQueryRepository().repository.DeleteSharedPlan, {
+			await useQuery("DeleteSharedPlan", {
 				sharedUuid: planningStore.shared[planUuid].shared_uuid,
 			}).execute();
 			await refreshStore();
@@ -91,7 +90,7 @@ export function useSharing(planUuid: string) {
 	async function createSharing(): Promise<void> {
 		if (!isShared.value) {
 			// call sharing creation
-			await useQuery(useQueryRepository().repository.CreateSharedPlan, {
+			await useQuery("CreateSharedPlan", {
 				planUuid: planUuid,
 			}).execute();
 			await refreshStore();

--- a/src/features/wrapper/useGameDataLoader.ts
+++ b/src/features/wrapper/useGameDataLoader.ts
@@ -1,7 +1,6 @@
 import { computed, reactive, ref, Ref, watch, watchEffect } from "vue";
 
 // Stores & Repository
-import { useQueryRepository } from "@/lib/query_cache/queryRepository";
 import { useQueryStore } from "@/lib/query_cache/queryStore";
 
 // Util
@@ -35,10 +34,7 @@ export function useGameDataLoader(
 			name: `Material Data`,
 			enabled: () => !!props.loadMaterials,
 			load: () => {
-				return queryStore.executeQuery(
-					useQueryRepository().repository.GetMaterials,
-					undefined
-				);
+				return queryStore.execute("GetMaterials", undefined);
 			},
 			onSuccess: (d: IMaterial[]) => emits("data:materials", d),
 		},
@@ -47,10 +43,7 @@ export function useGameDataLoader(
 			name: `Exchange Data`,
 			enabled: () => !!props.loadExchanges,
 			load: () => {
-				return queryStore.executeQuery(
-					useQueryRepository().repository.GetExchanges,
-					undefined
-				);
+				return queryStore.execute("GetExchanges", undefined);
 			},
 			onSuccess: (d: IExchange[]) => emits("data:exchanges", d),
 		},
@@ -59,10 +52,7 @@ export function useGameDataLoader(
 			name: `Building Data`,
 			enabled: () => !!props.loadBuildings,
 			load: () => {
-				return queryStore.executeQuery(
-					useQueryRepository().repository.GetBuildings,
-					undefined
-				);
+				return queryStore.execute("GetBuildings", undefined);
 			},
 			onSuccess: (d: IBuilding[]) => emits("data:buildings", d),
 		},
@@ -71,10 +61,7 @@ export function useGameDataLoader(
 			name: `Recipe Data`,
 			enabled: () => !!props.loadRecipes,
 			load: () => {
-				return queryStore.executeQuery(
-					useQueryRepository().repository.GetRecipes,
-					undefined
-				);
+				return queryStore.execute("GetRecipes", undefined);
 			},
 			onSuccess: (d: IRecipe[]) => emits("data:recipes", d),
 		},
@@ -83,12 +70,9 @@ export function useGameDataLoader(
 			name: `Planet '${props.loadPlanet}' Data`,
 			enabled: () => !!props.loadPlanet,
 			load: () => {
-				return queryStore.executeQuery(
-					useQueryRepository().repository.GetPlanet,
-					{
-						planetNaturalId: props.loadPlanet!,
-					}
-				);
+				return queryStore.execute("GetPlanet", {
+					planetNaturalId: props.loadPlanet!,
+				});
 			},
 			onSuccess: (d: IPlanet) => emits("data:planet", d),
 		},
@@ -97,12 +81,9 @@ export function useGameDataLoader(
 			name: `Planet '${props.loadPlanetMultiple?.join(", ")}' Data`,
 			enabled: () => !!props.loadPlanetMultiple,
 			load: () => {
-				return queryStore.executeQuery(
-					useQueryRepository().repository.GetMultiplePlanets,
-					{
-						planetNaturalIds: props.loadPlanetMultiple!,
-					}
-				);
+				return queryStore.execute("GetMultiplePlanets", {
+					planetNaturalIds: props.loadPlanetMultiple!,
+				});
 			},
 			onSuccess: (d: IPlanet[]) => emits("data:planet:multiple", d),
 		},

--- a/src/features/wrapper/usePlanningDataLoader.ts
+++ b/src/features/wrapper/usePlanningDataLoader.ts
@@ -58,23 +58,16 @@ export function usePlanningDataLoader(
 			name: "Shared Plan Configuration",
 			enabled: () => !!props.sharedPlanUuid,
 			load: () =>
-				queryStore.executeQuery(
-					useQueryRepository().repository.GetSharedPlan,
-					{
-						sharedPlanUuid: props.sharedPlanUuid!,
-					}
-				),
+				queryStore.execute("GetSharedPlan", {
+					sharedPlanUuid: props.sharedPlanUuid!,
+				}),
 			onSuccess: (data: IPlanShare) => emits("data:shared:plan", data),
 		},
 		{
 			key: "empireList",
 			name: "Empires Configurations",
 			enabled: () => !!props.empireList,
-			load: () =>
-				queryStore.executeQuery(
-					useQueryRepository().repository.GetAllEmpires,
-					undefined
-				),
+			load: () => queryStore.execute("GetAllEmpires", undefined),
 			onSuccess: (data: IPlanEmpireElement[]) => {
 				if (!props.empireUuid) {
 					/*
@@ -95,23 +88,16 @@ export function usePlanningDataLoader(
 			name: "Plan Configuration",
 			enabled: () => !!props.planUuid,
 			load: () =>
-				queryStore.executeQuery(
-					useQueryRepository().repository.GetPlan,
-					{
-						planUuid: props.planUuid!,
-					}
-				),
+				queryStore.execute("GetPlan", {
+					planUuid: props.planUuid!,
+				}),
 			onSuccess: (data: IPlan) => emits("data:plan", data),
 		},
 		{
 			key: "planList",
 			name: "All Plan Configurations",
 			enabled: () => !!props.planList,
-			load: () =>
-				queryStore.executeQuery(
-					useQueryRepository().repository.GetAllPlans,
-					undefined
-				),
+			load: () => queryStore.execute("GetAllPlans", undefined),
 			onSuccess: (data: IPlan[]) => {
 				const planetList: string[] = Array.from(
 					new Set(data.map((e) => e.planet_id)).values()
@@ -139,12 +125,9 @@ export function usePlanningDataLoader(
 							)!.data as IPlanShare
 					  ).baseplanner.planet_id
 					: props.planetNaturalId!;
-				return queryStore.executeQuery(
-					useQueryRepository().repository.GetPlanet,
-					{
-						planetNaturalId: id,
-					}
-				);
+				return queryStore.execute("GetPlanet", {
+					planetNaturalId: id,
+				});
 			},
 			onSuccess: (data: IPlanet) => emits("data:planet", data),
 		},
@@ -152,11 +135,7 @@ export function usePlanningDataLoader(
 			key: "cx",
 			name: "CX Configurations",
 			enabled: () => !!props.loadCX,
-			load: () =>
-				queryStore.executeQuery(
-					useQueryRepository().repository.GetAllCX,
-					undefined
-				),
+			load: () => queryStore.execute("GetAllCX", undefined),
 			onSuccess: (d: ICX[]) => {
 				emits("data:cx", d);
 				if (!props.cxUuid && d.length > 0) {
@@ -168,11 +147,7 @@ export function usePlanningDataLoader(
 			key: "sharedList",
 			name: "Shared Plan Configurations",
 			enabled: () => !!props.loadShared,
-			load: () =>
-				queryStore.executeQuery(
-					useQueryRepository().repository.GetAllShared,
-					undefined
-				),
+			load: () => queryStore.execute("GetAllShared", undefined),
 			onSuccess: (data: IShared[]) => emits("data:shared", data),
 		},
 		{
@@ -180,12 +155,9 @@ export function usePlanningDataLoader(
 			name: "Empire Plans",
 			enabled: () => !!props.empireUuid,
 			load: () =>
-				queryStore.executeQuery(
-					useQueryRepository().repository.GetEmpirePlans,
-					{
-						empireUuid: props.empireUuid!,
-					}
-				),
+				queryStore.execute("GetEmpirePlans", {
+					empireUuid: props.empireUuid!,
+				}),
 			onSuccess: (data: IPlan[]) => {
 				// emit empire data
 				emits("data:empire:plans", data);

--- a/src/lib/piniaBroadcastChannelPlugin.ts
+++ b/src/lib/piniaBroadcastChannelPlugin.ts
@@ -11,13 +11,16 @@ declare module "pinia" {
 	}
 }
 
-function safeStructuredClone(value: any) {
+function safeStructuredClone<T>(value: T) {
 	const raw = toRaw(value);
 	try {
-		return structuredClone(raw);
+		if (typeof (globalThis as any).structuredClone === "function")
+			return (globalThis as any).structuredClone(raw);
 	} catch {
-		return JSON.parse(JSON.stringify(raw));
+		// ignore
 	}
+	// JSON fallback
+	return JSON.parse(JSON.stringify(raw));
 }
 
 /** Return true for plain `{}` objects (not arrays, not class instances) */
@@ -130,20 +133,17 @@ function makeClientId() {
 	);
 }
 
-function serializeForComparison(v: any) {
+function serializeForComparison<T>(v: T) {
 	try {
-		return JSON.stringify(v);
+		if (typeof (globalThis as any).structuredClone === "function")
+			return (globalThis as any).structuredClone(v);
 	} catch {
-		// fallback coarse stringify
-		try {
-			return String(v);
-		} catch {
-			return "";
-		}
+		// ignore
 	}
+	return JSON.stringify(v);
 }
 
-export function createBroadcastChannelDiffPlugin(globalOptions?: {
+export function createBroadcastChannelPlugin(globalOptions?: {
 	channel?: string;
 	debounce?: number;
 }) {

--- a/src/lib/piniaBroadcastChannelPlugin.ts
+++ b/src/lib/piniaBroadcastChannelPlugin.ts
@@ -24,12 +24,12 @@ function safeStructuredClone<T>(value: T) {
 }
 
 /** Return true for plain `{}` objects (not arrays, not class instances) */
-function isPlainObject(v: any): v is Record<string, any> {
+function isPlainObject(v: unknown): v is Record<string, any> {
 	return Object.prototype.toString.call(v) === "[object Object]";
 }
 
 /** Shallow equality for arrays (fast path) */
-function arraysEqual(a: any[], b: any[]) {
+function arraysEqual(a: unknown[], b: any[]) {
 	if (a === b) return true;
 	if (a.length !== b.length) return false;
 	for (let i = 0; i < a.length; i++) {
@@ -48,7 +48,7 @@ function arraysEqual(a: any[], b: any[]) {
  *
  * Returns the value that should be assigned to the store field (often the same `current` reference).
  */
-function updateReactiveState(current: any, incoming: any): any {
+function updateReactiveState(current: unknown, incoming: any): any {
 	// fast reference equality -> nothing to do
 	if (current === incoming) return current;
 
@@ -112,9 +112,12 @@ function updateReactiveState(current: any, incoming: any): any {
 	return incoming;
 }
 
-function debouncePerPath(fn: (key: string, value: any) => void, delay = 50) {
+function debouncePerPath(
+	fn: (key: string, value: unknown) => void,
+	delay: number
+) {
 	const timers = new Map<string, number>();
-	return (key: string, value: any) => {
+	return (key: string, value: unknown) => {
 		const t = timers.get(key);
 		if (t !== undefined) window.clearTimeout(t);
 		const id = window.setTimeout(() => {
@@ -172,7 +175,7 @@ export function createBroadcastChannelPlugin(globalOptions?: {
 		// store serialized last values for simple change detection
 		const lastValues = new Map<string, string>();
 
-		const broadcaster = (path: string, value: any) => {
+		const broadcaster = (path: string, value: unknown) => {
 			const clonedValue = safeStructuredClone(value);
 			const msg = {
 				storeId: store.$id,
@@ -197,7 +200,7 @@ export function createBroadcastChannelPlugin(globalOptions?: {
 			}
 		};
 
-		const applyer = (path: string, payloadValue: any) => {
+		const applyer = (path: string, payloadValue: unknown) => {
 			try {
 				isApplyingRemote = true;
 				store.$state[path] = updateReactiveState(
@@ -228,7 +231,7 @@ export function createBroadcastChannelPlugin(globalOptions?: {
 			if (isApplyingRemote) return;
 			try {
 				for (const path of paths) {
-					const val = (state as any)[path];
+					const val = state[path];
 					const cloned = safeStructuredClone(val);
 					const serialized = serializeForComparison(cloned);
 					const prevSerialized = lastValues.get(path);

--- a/src/lib/piniaBroadcastChannelPlugin.ts
+++ b/src/lib/piniaBroadcastChannelPlugin.ts
@@ -48,7 +48,7 @@ function arraysEqual(a: any[], b: any[]) {
  *
  * Returns the value that should be assigned to the store field (often the same `current` reference).
  */
-export function updateReactiveState(current: any, incoming: any): any {
+function updateReactiveState(current: any, incoming: any): any {
 	// fast reference equality -> nothing to do
 	if (current === incoming) return current;
 

--- a/src/lib/piniaLocalStorageWatcher.ts
+++ b/src/lib/piniaLocalStorageWatcher.ts
@@ -1,0 +1,281 @@
+import { PiniaPluginContext } from "pinia";
+import { isReactive, reactive, toRaw } from "vue";
+
+declare module "pinia" {
+	export interface DefineStoreOptionsBase<S extends StateTree, Store> {
+		broadcastWatch?: {
+			pick?: string[];
+			debounce?: number;
+			channel?: string;
+		};
+	}
+}
+
+function safeStructuredClone(value: any) {
+	const raw = toRaw(value);
+	try {
+		return structuredClone(raw);
+	} catch {
+		return JSON.parse(JSON.stringify(raw));
+	}
+}
+
+/** Return true for plain `{}` objects (not arrays, not class instances) */
+function isPlainObject(v: any): v is Record<string, any> {
+	return Object.prototype.toString.call(v) === "[object Object]";
+}
+
+/** Shallow equality for arrays (fast path) */
+function arraysEqual(a: any[], b: any[]) {
+	if (a === b) return true;
+	if (a.length !== b.length) return false;
+	for (let i = 0; i < a.length; i++) {
+		if (a[i] !== b[i]) return false;
+	}
+	return true;
+}
+
+/**
+ * Update reactive `current` with `incoming` while preserving reactivity when possible.
+ *
+ * - Arrays: if both arrays and identical items -> no-op; else splice to update in-place.
+ * - Plain objects: merge recursively (preserve existing reactive objects).
+ * - Non-plain objects (Date, Map, class instances): replace (caller is responsible for serializability).
+ * - Primitives: replace (but return current if === to avoid triggering watchers).
+ *
+ * Returns the value that should be assigned to the store field (often the same `current` reference).
+ */
+export function updateReactiveState(current: any, incoming: any): any {
+	// fast reference equality -> nothing to do
+	if (current === incoming) return current;
+
+	// handle arrays
+	if (Array.isArray(incoming)) {
+		if (Array.isArray(current)) {
+			// fast path: exact same primitive elements -> no-op
+			if (arraysEqual(current, incoming)) return current;
+
+			// update in-place to preserve reactivity
+			current.splice(0, current.length, ...incoming);
+			return current;
+		} else {
+			// replace with a reactive array if current wasn't an array
+			return reactive(Array.from(incoming));
+		}
+	}
+
+	// handle plain objects (recursive merge)
+	if (incoming && isPlainObject(incoming)) {
+		// If current is not a plain object, replace with reactive copy
+		if (!current || !isPlainObject(current) || Array.isArray(current)) {
+			// preserve reactivity by wrapping a new object
+			return reactive({ ...incoming });
+		}
+
+		// If either is reactive proxy, work on raw to avoid double proxies
+		const curRaw = isReactive(current) ? toRaw(current) : current;
+
+		// Merge keys from incoming into current (recursive)
+		for (const key of Object.keys(incoming)) {
+			const incVal = incoming[key];
+			const curVal = curRaw[key];
+
+			// If both plain objects -> recurse
+			if (isPlainObject(incVal) && isPlainObject(curVal)) {
+				// recursive merge keeps nested reactive objects intact
+				updateReactiveState(curVal, incVal);
+			} else if (Array.isArray(incVal) && Array.isArray(curVal)) {
+				// arrays: reuse logic above (avoid extra allocate)
+				if (!arraysEqual(curVal, incVal)) {
+					curVal.splice(0, curVal.length, ...incVal);
+				}
+			} else {
+				// primitives or mismatched types -> assign directly (this mutates reactive proxy)
+				curRaw[key] = incVal;
+			}
+		}
+
+		// Remove keys that no longer exist in incoming
+		for (const key of Object.keys(curRaw)) {
+			if (!(key in incoming)) {
+				delete curRaw[key];
+			}
+		}
+
+		return current;
+	}
+
+	// Non-plain objects (Date, Map, Set, class instances) or primitives: direct replacement
+	return incoming;
+}
+
+function debouncePerPath(fn: (key: string, value: any) => void, delay = 50) {
+	const timers = new Map<string, number>();
+	return (key: string, value: any) => {
+		const t = timers.get(key);
+		if (t !== undefined) window.clearTimeout(t);
+		const id = window.setTimeout(() => {
+			timers.delete(key);
+			fn(key, value);
+		}, delay) as unknown as number;
+		timers.set(key, id);
+	};
+}
+
+/** Client id to ignore own messages */
+function makeClientId() {
+	return (
+		globalThis.crypto?.randomUUID?.() ??
+		`${Date.now()}-${Math.random().toString(36).slice(2)}`
+	);
+}
+
+function serializeForComparison(v: any) {
+	try {
+		return JSON.stringify(v);
+	} catch {
+		// fallback coarse stringify
+		try {
+			return String(v);
+		} catch {
+			return "";
+		}
+	}
+}
+
+export function createBroadcastChannelDiffPlugin(globalOptions?: {
+	channel?: string;
+	debounce?: number;
+}) {
+	const clientId = makeClientId();
+	const defaultChannel = globalOptions?.channel ?? "pinia_sync";
+	const defaultDebounce = globalOptions?.debounce;
+
+	return (context: PiniaPluginContext) => {
+		const store = context.store;
+		const options: any = context.options ?? {};
+
+		const cfg = options.broadcastWatch ?? {};
+		const paths: string[] = Array.isArray(cfg.pick) ? cfg.pick : [];
+		if (!paths.length) return;
+
+		const channelName = cfg.channel ?? defaultChannel;
+		const resolvedDebounceRaw =
+			typeof cfg.debounce === "number" ? cfg.debounce : defaultDebounce;
+		const useDebounce =
+			typeof resolvedDebounceRaw === "number" && resolvedDebounceRaw > 0;
+		const debounceMs = useDebounce ? (resolvedDebounceRaw as number) : 0;
+
+		const bc = new BroadcastChannel(channelName);
+		let isApplyingRemote = false;
+
+		// store serialized last values for simple change detection
+		const lastValues = new Map<string, string>();
+
+		const broadcaster = (path: string, value: any) => {
+			const clonedValue = safeStructuredClone(value);
+			const msg = {
+				storeId: store.$id,
+				clientId,
+				ts: Date.now(),
+				updates: {
+					[path]: clonedValue,
+				},
+			};
+			try {
+				bc.postMessage(msg);
+			} catch {
+				try {
+					const jsonSafe = JSON.parse(JSON.stringify(msg));
+					bc.postMessage(jsonSafe);
+				} catch (err) {
+					console.warn(
+						"BroadcastChannel postMessage failed (json fallback)",
+						err
+					);
+				}
+			}
+		};
+
+		const applyer = (path: string, payloadValue: any) => {
+			try {
+				isApplyingRemote = true;
+				store.$state[path] = updateReactiveState(
+					store.$state[path],
+					payloadValue
+				);
+				// update lastValues, not going to rebroadcast it
+				try {
+					lastValues.set(path, serializeForComparison(payloadValue));
+				} catch {
+					// ignore
+				}
+			} finally {
+				setTimeout(() => {
+					isApplyingRemote = false;
+				}, 0);
+			}
+		};
+
+		const broadcastPerPath = useDebounce
+			? debouncePerPath(
+					(path, value) => broadcaster(path, value),
+					debounceMs
+			  )
+			: broadcaster;
+
+		const unsubscribe = store.$subscribe((_mutation, state) => {
+			if (isApplyingRemote) return;
+			try {
+				for (const path of paths) {
+					const val = (state as any)[path];
+					const cloned = safeStructuredClone(val);
+					const serialized = serializeForComparison(cloned);
+					const prevSerialized = lastValues.get(path);
+
+					// only broadcast if not the same as last send
+					if (prevSerialized !== serialized) {
+						broadcastPerPath(path, cloned);
+						lastValues.set(path, serialized);
+					}
+				}
+			} catch (err) {
+				console.warn("Error broadcasting Pinia updates", err);
+			}
+		});
+
+		// Handle incoming
+		const onMessage = (ev: MessageEvent) => {
+			const data = ev.data;
+			if (!data || data.storeId !== store.$id) return;
+			if (data.clientId === clientId) return;
+
+			for (const path of Object.keys(data.updates)) {
+				if (!paths.includes(path)) continue;
+				applyer(path, data.updates[path]);
+			}
+		};
+		bc.addEventListener("message", onMessage);
+
+		// Cleanup
+		const onBeforeUnload = () => {
+			try {
+				// send out all thats still pending
+				unsubscribe();
+			} catch (err) {
+				console.warn(err);
+			}
+			try {
+				bc.removeEventListener("message", onMessage);
+			} catch (err) {
+				console.warn(err);
+			}
+			try {
+				bc.close();
+			} catch (err) {
+				console.warn(err);
+			}
+		};
+		window.addEventListener("beforeunload", onBeforeUnload);
+	};
+}

--- a/src/lib/query_cache/QueryCacheView.vue
+++ b/src/lib/query_cache/QueryCacheView.vue
@@ -4,25 +4,26 @@
 
 	import { PButton, PTag } from "@/ui";
 	import { NTable } from "naive-ui";
-	import { QueryState } from "./queryCache.types";
 
 	// Grab the Pinia store
 	const queryStore = useQueryStore();
 
 	// Build a list of all cache entries
 	const entries = computed(() => {
-		return Array.from(queryStore.cache.entries()).map(([key, state]) => ({
-			key,
-			state: state as QueryState<unknown, unknown>,
-			// Prettify JSON or show placeholder
-			jsonData:
-				state.data !== null
-					? JSON.stringify(state.data, null, 2)
-					: "null",
-			expireAt: state.expireTime
-				? state.timestamp + state.expireTime
-				: null,
-		}));
+		return Array.from(queryStore.cacheState.entries()).map(
+			([key, state]) => ({
+				key,
+				state,
+				// Prettify JSON or show placeholder
+				jsonData:
+					state.data !== null
+						? JSON.stringify(state.data, null, 2)
+						: "null",
+				expireAt: state.expireTime
+					? state.timestamp + state.expireTime
+					: null,
+			})
+		);
 	});
 </script>
 
@@ -88,7 +89,7 @@
 					</td>
 					<td>
 						<PTag
-							v-if="entry.state.definition?.autoRefetch"
+							v-if="entry.state.autoRefetch"
 							:bordered="false"
 							type="success">
 							yes

--- a/src/lib/query_cache/QueryCacheView.vue
+++ b/src/lib/query_cache/QueryCacheView.vue
@@ -95,7 +95,7 @@
 						<PTag v-else :bordered="false" type="error"> no </PTag>
 					</td>
 					<td>
-						<pre>{{ entry.jsonData.length }}</pre>
+						<pre>{{ entry.jsonData?.length }}</pre>
 					</td>
 					<td>
 						<PButton

--- a/src/lib/query_cache/QueryCacheView.vue
+++ b/src/lib/query_cache/QueryCacheView.vue
@@ -10,20 +10,18 @@
 
 	// Build a list of all cache entries
 	const entries = computed(() => {
-		return Array.from(queryStore.cacheState.entries()).map(
-			([key, state]) => ({
-				key,
-				state,
-				// Prettify JSON or show placeholder
-				jsonData:
-					state.data !== null
-						? JSON.stringify(state.data, null, 2)
-						: "null",
-				expireAt: state.expireTime
-					? state.timestamp + state.expireTime
-					: null,
-			})
-		);
+		return Object.entries(queryStore.cacheState).map(([key, state]) => ({
+			key,
+			state,
+			// Prettify JSON or show placeholder
+			jsonData:
+				state.data !== null
+					? JSON.stringify(state.data, null, 2)
+					: "null",
+			expireAt: state.expireTime
+				? state.timestamp + state.expireTime
+				: null,
+		}));
 	});
 </script>
 

--- a/src/lib/query_cache/queryCache.types.ts
+++ b/src/lib/query_cache/queryCache.types.ts
@@ -1,22 +1,29 @@
 export type JSONObject = { [key: string]: JSONValue };
 export type JSONValue = null | boolean | number | string | object;
 
-export interface QueryState<TParams, TData> {
-	// definition
-	definition: QueryDefinition<TParams, TData> | null;
+export interface IQueryState<TParams, TData> {
+	definitionName: string;
 	params: TParams | null;
-	// state
 	data: TData | null;
 	loading: boolean;
 	error: Error | null;
 	timestamp: number;
+	autoRefetch?: boolean;
 	expireTime?: number;
 }
 
-export interface QueryDefinition<TParams, TData> {
-	key: (params?: TParams) => JSONValue;
-	fetchFn: (params?: TParams) => Promise<TData>;
-	autoRefetch?: boolean;
-	expireTime?: number;
-	persist?: boolean;
-}
+export type IQueryDefinition<TParams, TData> = [TParams] extends [undefined]
+	? {
+			key: () => JSONValue;
+			fetchFn: () => Promise<TData>;
+			autoRefetch?: boolean;
+			expireTime?: number;
+			persist?: boolean;
+	  }
+	: {
+			key: (params: TParams) => JSONValue;
+			fetchFn: (params: TParams) => Promise<TData>;
+			autoRefetch?: boolean;
+			expireTime?: number;
+			persist?: boolean;
+	  };

--- a/src/lib/query_cache/queryRepository.ts
+++ b/src/lib/query_cache/queryRepository.ts
@@ -1,4 +1,4 @@
-import { QueryDefinition } from "@/lib/query_cache/queryCache.types";
+import { IQueryDefinition } from "@/lib/query_cache/queryCache.types";
 
 // config
 import config from "@/lib/config";
@@ -56,7 +56,7 @@ import {
 } from "@/features/api/sharingData.api";
 
 // Types & Interfaces
-import { QueryRepositoryType } from "@/lib/query_cache/queryRepository.types";
+import { IQueryRepository } from "@/lib/query_cache/queryRepository.types";
 
 import {
 	IBuilding,
@@ -127,7 +127,7 @@ export function useQueryRepository() {
 	const planningStore = usePlanningStore();
 	const userStore = useUserStore();
 
-	const queryRepository: QueryRepositoryType = {
+	const repository: IQueryRepository = {
 		GetMaterials: {
 			key: () => ["gamedata", "materials"],
 			fetchFn: async () => {
@@ -138,7 +138,7 @@ export function useQueryRepository() {
 			autoRefetch: true,
 			expireTime: 60_000 * config.GAME_DATA_STALE_MINUTES_MATERIALS,
 			persist: true,
-		} as QueryDefinition<void, IMaterial[]>,
+		} as IQueryDefinition<undefined, IMaterial[]>,
 		GetExchanges: {
 			key: () => ["gamedata", "exchanges"],
 			fetchFn: async () => {
@@ -149,7 +149,7 @@ export function useQueryRepository() {
 			autoRefetch: true,
 			expireTime: 60_000 * config.GAME_DATA_STALE_MINUTES_EXCHANGES,
 			persist: true,
-		} as QueryDefinition<void, IExchange[]>,
+		} as IQueryDefinition<undefined, IExchange[]>,
 		GetRecipes: {
 			key: () => ["gamedata", "recipes"],
 			fetchFn: async () => {
@@ -160,7 +160,7 @@ export function useQueryRepository() {
 			autoRefetch: true,
 			expireTime: 60_000 * config.GAME_DATA_STALE_MINUTES_RECIPES,
 			persist: true,
-		} as QueryDefinition<void, IRecipe[]>,
+		} as IQueryDefinition<undefined, IRecipe[]>,
 		GetBuildings: {
 			key: () => ["gamedata", "buildings"],
 			fetchFn: async () => {
@@ -171,7 +171,7 @@ export function useQueryRepository() {
 			autoRefetch: true,
 			expireTime: 60_000 * config.GAME_DATA_STALE_MINUTES_BUILDINGS,
 			persist: true,
-		} as QueryDefinition<void, IBuilding[]>,
+		} as IQueryDefinition<undefined, IBuilding[]>,
 		GetPlanet: {
 			key: (params: { planetNaturalId: string }) => [
 				"gamedata",
@@ -188,7 +188,7 @@ export function useQueryRepository() {
 			expireTime: 60_000 * config.GAME_DATA_STALE_MINUTES_PLANETS,
 			autoRefetch: true,
 			persist: true,
-		} as QueryDefinition<{ planetNaturalId: string }, IPlanet>,
+		} as IQueryDefinition<{ planetNaturalId: string }, IPlanet>,
 		GetMultiplePlanets: {
 			key: (params: { planetNaturalIds: string[] }) => [
 				"gamedata",
@@ -207,7 +207,7 @@ export function useQueryRepository() {
 					data.forEach((p) => {
 						queryStore.addCacheState(
 							["gamedata", "planet", p.PlanetNaturalId],
-							queryRepository.GetPlanet,
+							"GetPlanet",
 							{ planetNaturalId: p.PlanetNaturalId },
 							p
 						);
@@ -221,7 +221,7 @@ export function useQueryRepository() {
 			expireTime: 60_000 * config.GAME_DATA_STALE_MINUTES_PLANETS,
 			autoRefetch: true,
 			persist: true,
-		} as QueryDefinition<{ planetNaturalIds: string[] }, IPlanet[]>,
+		} as IQueryDefinition<{ planetNaturalIds: string[] }, IPlanet[]>,
 		GetPlanetSearchSingle: {
 			key: (params: { searchId: string }) => [
 				"gamedata",
@@ -235,7 +235,7 @@ export function useQueryRepository() {
 			expireTime: 60_000 * config.GAME_DATA_STALE_MINUTES_PLANETS,
 			persist: true,
 			autoRefetch: false,
-		} as QueryDefinition<{ searchId: string }, IPlanet[]>,
+		} as IQueryDefinition<{ searchId: string }, IPlanet[]>,
 		PostPlanetSearch: {
 			key: (params: { searchData: IPlanetSearchAdvanced }) => [
 				"gamedata",
@@ -249,7 +249,7 @@ export function useQueryRepository() {
 			expireTime: 60_000 * config.GAME_DATA_STALE_MINUTES_PLANETS,
 			persist: true,
 			autoRefetch: false,
-		} as QueryDefinition<{ searchData: IPlanetSearchAdvanced }, IPlanet[]>,
+		} as IQueryDefinition<{ searchData: IPlanetSearchAdvanced }, IPlanet[]>,
 		GetSharedPlan: {
 			key: (params: { sharedPlanUuid: string }) => [
 				"planningdata",
@@ -262,7 +262,7 @@ export function useQueryRepository() {
 			persist: true,
 			autoRefetch: false,
 			expireTime: 10_000,
-		} as QueryDefinition<{ sharedPlanUuid: string }, IPlanShare>,
+		} as IQueryDefinition<{ sharedPlanUuid: string }, IPlanShare>,
 		GetAllShared: {
 			key: () => ["planningdata", "shared", "list"],
 			fetchFn: async () => {
@@ -273,7 +273,7 @@ export function useQueryRepository() {
 			persist: true,
 			autoRefetch: true,
 			expireTime: 60_000 * 60,
-		} as QueryDefinition<void, IShared[]>,
+		} as IQueryDefinition<void, IShared[]>,
 		DeleteSharedPlan: {
 			key: (params: { sharedUuid: string }) => [
 				"planningdata",
@@ -291,7 +291,7 @@ export function useQueryRepository() {
 			},
 			persist: false,
 			autoRefetch: false,
-		} as QueryDefinition<{ sharedUuid: string }, boolean>,
+		} as IQueryDefinition<{ sharedUuid: string }, boolean>,
 		CreateSharedPlan: {
 			key: (params: { planUuid: string }) => [
 				"planningdata",
@@ -308,7 +308,7 @@ export function useQueryRepository() {
 			},
 			persist: false,
 			autoRefetch: false,
-		} as QueryDefinition<{ planUuid: string }, ISharedCreateResponse>,
+		} as IQueryDefinition<{ planUuid: string }, ISharedCreateResponse>,
 		CreateEmpire: {
 			key: () => ["planningdata", "empire", "create"],
 			fetchFn: async (params: { data: IEmpireCreatePayload }) => {
@@ -320,7 +320,7 @@ export function useQueryRepository() {
 			},
 			autoRefetch: false,
 			persist: false,
-		} as QueryDefinition<{ data: IEmpireCreatePayload }, IPlanEmpire>,
+		} as IQueryDefinition<{ data: IEmpireCreatePayload }, IPlanEmpire>,
 		DeleteEmpire: {
 			key: (params: { empireUuid: string }) => [
 				"planningdata",
@@ -337,7 +337,7 @@ export function useQueryRepository() {
 			},
 			autoRefetch: false,
 			persist: false,
-		} as QueryDefinition<{ empireUuid: string }, boolean>,
+		} as IQueryDefinition<{ empireUuid: string }, boolean>,
 		PatchEmpireCXJunctions: {
 			key: () => ["planningdata", "empire", "cx", "junctions"],
 			fetchFn: async (params: { junctions: ICXEmpireJunction[] }) => {
@@ -352,7 +352,7 @@ export function useQueryRepository() {
 			},
 			autoRefetch: false,
 			persist: false,
-		} as QueryDefinition<{ junctions: ICXEmpireJunction[] }, ICX[]>,
+		} as IQueryDefinition<{ junctions: ICXEmpireJunction[] }, ICX[]>,
 		PatchCX: {
 			key: (params: { cxUuid: string }) => [
 				"planningdata",
@@ -372,7 +372,7 @@ export function useQueryRepository() {
 			},
 			autoRefetch: false,
 			persist: false,
-		} as QueryDefinition<{ cxUuid: string; data: ICXData }, ICXData>,
+		} as IQueryDefinition<{ cxUuid: string; data: ICXData }, ICXData>,
 		GetAllEmpires: {
 			key: () => ["planningdata", "empire", "list"],
 			fetchFn: async () => {
@@ -382,7 +382,7 @@ export function useQueryRepository() {
 			},
 			autoRefetch: false,
 			persist: true,
-		} as QueryDefinition<void, IPlanEmpireElement[]>,
+		} as IQueryDefinition<void, IPlanEmpireElement[]>,
 		GetEmpirePlans: {
 			key: (params: { empireUuid: string }) => [
 				"planningdata",
@@ -399,7 +399,7 @@ export function useQueryRepository() {
 					data.forEach((p) =>
 						queryStore.addCacheState(
 							["planningdata", "plan", p.uuid],
-							queryRepository.GetPlan,
+							"GetPlan",
 							{ planUuid: p.uuid! },
 							p
 						)
@@ -412,7 +412,7 @@ export function useQueryRepository() {
 			},
 			autoRefetch: false,
 			persist: true,
-		} as QueryDefinition<{ empireUuid: string }, IPlan[]>,
+		} as IQueryDefinition<{ empireUuid: string }, IPlan[]>,
 		PatchEmpire: {
 			key: (params: { empireUuid: string }) => [
 				"planningdata",
@@ -435,7 +435,7 @@ export function useQueryRepository() {
 			},
 			autoRefetch: false,
 			persist: false,
-		} as QueryDefinition<
+		} as IQueryDefinition<
 			{ empireUuid: string; data: IEmpirePatchPayload },
 			IPlanEmpire
 		>,
@@ -458,7 +458,7 @@ export function useQueryRepository() {
 			},
 			autoRefetch: false,
 			persist: false,
-		} as QueryDefinition<
+		} as IQueryDefinition<
 			{ junctions: IPlanEmpireJunction[] },
 			IPlanEmpireElement[]
 		>,
@@ -473,7 +473,7 @@ export function useQueryRepository() {
 			},
 			autoRefetch: false,
 			persist: false,
-		} as QueryDefinition<{ cxName: string }, ICX>,
+		} as IQueryDefinition<{ cxName: string }, ICX>,
 		DeleteCX: {
 			key: (params: { cxUuid: string }) => [
 				"planningdata",
@@ -490,7 +490,7 @@ export function useQueryRepository() {
 			},
 			autoRefetch: false,
 			persist: false,
-		} as QueryDefinition<{ cxUuid: string }, boolean>,
+		} as IQueryDefinition<{ cxUuid: string }, boolean>,
 		GetAllCX: {
 			key: () => ["planningdata", "cx"],
 			fetchFn: async () => {
@@ -500,7 +500,7 @@ export function useQueryRepository() {
 			},
 			autoRefetch: false,
 			persist: true,
-		} as QueryDefinition<void, ICX[]>,
+		} as IQueryDefinition<void, ICX[]>,
 		GetPlan: {
 			key: (params: { planUuid: string }) => [
 				"planningdata",
@@ -514,7 +514,7 @@ export function useQueryRepository() {
 			},
 			autoRefetch: false,
 			persist: true,
-		} as QueryDefinition<{ planUuid: string }, IPlan>,
+		} as IQueryDefinition<{ planUuid: string }, IPlan>,
 		GetAllPlans: {
 			key: () => ["planningdata", "plan", "list"],
 			fetchFn: async () => {
@@ -526,7 +526,7 @@ export function useQueryRepository() {
 					data.forEach((p) =>
 						queryStore.addCacheState(
 							["planningdata", "plan", p.uuid],
-							queryRepository.GetPlan,
+							"GetPlan",
 							{ planUuid: p.uuid! },
 							p
 						)
@@ -539,7 +539,7 @@ export function useQueryRepository() {
 			},
 			autoRefetch: false,
 			persist: true,
-		} as QueryDefinition<void, IPlan[]>,
+		} as IQueryDefinition<void, IPlan[]>,
 		ClonePlan: {
 			key: (params: { planUuid: string; cloneName: string }) => [
 				"planningdata",
@@ -567,7 +567,7 @@ export function useQueryRepository() {
 			},
 			autoRefetch: false,
 			persist: false,
-		} as QueryDefinition<
+		} as IQueryDefinition<
 			{ planUuid: string; cloneName: string },
 			IPlanCloneResponse
 		>,
@@ -598,7 +598,7 @@ export function useQueryRepository() {
 			},
 			autoRefetch: false,
 			persist: false,
-		} as QueryDefinition<{ planUuid: string }, boolean>,
+		} as IQueryDefinition<{ planUuid: string }, boolean>,
 		CreatePlan: {
 			key: () => ["planningdata", "plan", "create"],
 			fetchFn: async (params: { data: IPlanCreateData }) => {
@@ -613,7 +613,7 @@ export function useQueryRepository() {
 			},
 			autoRefetch: false,
 			persist: false,
-		} as QueryDefinition<
+		} as IQueryDefinition<
 			{ data: IPlanCreateData },
 			PlanSaveCreateResponseType
 		>,
@@ -639,7 +639,7 @@ export function useQueryRepository() {
 			},
 			autoRefetch: false,
 			persist: false,
-		} as QueryDefinition<
+		} as IQueryDefinition<
 			{ planUuid: string; data: IPlanSaveData },
 			PlanSaveCreateResponseType
 		>,
@@ -652,7 +652,7 @@ export function useQueryRepository() {
 			},
 			autoRefetch: false,
 			persist: false,
-		} as QueryDefinition<{ data: IPlanPatchMaterialIOElement[] }, boolean>,
+		} as IQueryDefinition<{ data: IPlanPatchMaterialIOElement[] }, boolean>,
 		GetExplorationData: {
 			key: (params: {
 				exchangeTicker: string;
@@ -680,7 +680,7 @@ export function useQueryRepository() {
 			autoRefetch: false,
 			persist: true,
 			expireTime: 60_000 * 15, // 15 minutes,
-		} as QueryDefinition<
+		} as IQueryDefinition<
 			{
 				exchangeTicker: string;
 				materialTicker: string;
@@ -699,7 +699,7 @@ export function useQueryRepository() {
 			autoRefetch: true,
 			persist: true,
 			expireTime: 60_000 * 15, // 15 minutes
-		} as QueryDefinition<void, IFIOStorage>,
+		} as IQueryDefinition<void, IFIOStorage>,
 		GetFIOSites: {
 			key: () => ["gamedata", "fio", "sites"],
 			fetchFn: async () => {
@@ -711,7 +711,7 @@ export function useQueryRepository() {
 			autoRefetch: true,
 			persist: true,
 			expireTime: 60_000 * 15, // 15 minutes
-		} as QueryDefinition<void, IFIOSites>,
+		} as IQueryDefinition<void, IFIOSites>,
 		GetPlanetLastPOPR: {
 			key: (params: { planetNaturalId: string }) => [
 				"gamedata",
@@ -726,7 +726,7 @@ export function useQueryRepository() {
 			autoRefetch: false,
 			persist: true,
 			expireTime: 60_000 * config.GAME_DATA_STALE_MINUTES_PLANETS,
-		} as QueryDefinition<{ planetNaturalId: string }, IPopulationReport>,
+		} as IQueryDefinition<{ planetNaturalId: string }, IPopulationReport>,
 		OptimizeHabitation: {
 			key: (params: IOptimizeHabitationPayload) => [
 				"planningdata",
@@ -740,7 +740,7 @@ export function useQueryRepository() {
 			autoRefetch: false,
 			persist: true,
 			expireTime: 60_000 * config.GAME_DATA_STALE_MINUTES_PLANETS,
-		} as QueryDefinition<
+		} as IQueryDefinition<
 			IOptimizeHabitationPayload,
 			IOptimizeHabitationResponse
 		>,
@@ -753,7 +753,7 @@ export function useQueryRepository() {
 			},
 			autoRefetch: false,
 			persist: false,
-		} as QueryDefinition<IUserProfilePatch, IUserProfile>,
+		} as IQueryDefinition<IUserProfilePatch, IUserProfile>,
 		PostUserResendEmailVerification: {
 			key: () => ["user", "verification", "resend"],
 			fetchFn: async () => {
@@ -761,7 +761,7 @@ export function useQueryRepository() {
 			},
 			autoRefetch: false,
 			persist: false,
-		} as QueryDefinition<null, boolean>,
+		} as IQueryDefinition<null, boolean>,
 		PatchUserChangePassword: {
 			key: () => ["user", "password", "patch"],
 			fetchFn: async (params: IUserChangePasswordPayload) => {
@@ -775,7 +775,7 @@ export function useQueryRepository() {
 			},
 			autoRefetch: false,
 			persist: false,
-		} as QueryDefinition<IUserChangePasswordPayload, boolean>,
+		} as IQueryDefinition<IUserChangePasswordPayload, boolean>,
 		PostUserVerifyEmail: {
 			key: () => ["user", "verification", "check"],
 			fetchFn: async (params: IUserVerifyEmailPayload) => {
@@ -789,17 +789,10 @@ export function useQueryRepository() {
 			},
 			autoRefetch: false,
 			persist: false,
-		} as QueryDefinition<IUserVerifyEmailPayload, boolean>,
+		} as IQueryDefinition<IUserVerifyEmailPayload, boolean>,
 	};
 
-	function get(id: keyof QueryRepositoryType) {
-		if (queryRepository[id]) return queryRepository[id];
-
-		throw new Error(`'${id} is not present in query repository.`);
-	}
-
 	return {
-		get,
-		repository: queryRepository,
+		repository,
 	};
 }

--- a/src/lib/query_cache/queryRepository.types.ts
+++ b/src/lib/query_cache/queryRepository.types.ts
@@ -1,4 +1,7 @@
-import { QueryDefinition } from "@/lib/query_cache/queryCache.types";
+import {
+	IQueryDefinition,
+	JSONValue,
+} from "@/lib/query_cache/queryCache.types";
 import {
 	IBuilding,
 	IExchange,
@@ -55,68 +58,90 @@ import {
 	IUserVerifyEmailPayload,
 } from "@/features/api/userData.types";
 
-export type QueryRepositoryType = {
-	GetMaterials: QueryDefinition<void, IMaterial[]>;
-	GetExchanges: QueryDefinition<void, IExchange[]>;
-	GetRecipes: QueryDefinition<void, IRecipe[]>;
-	GetBuildings: QueryDefinition<void, IBuilding[]>;
-	GetPlanet: QueryDefinition<{ planetNaturalId: string }, IPlanet>;
-	GetMultiplePlanets: QueryDefinition<
+/*
+ * To be honest, this typing for Query Params and their data is a complete
+ * shitshow, I'm still not 100 % sure why this is working, but if someone
+ * is able to make this easier and more readable, please do! /jplacht
+ */
+
+export type ParamsOfDefinition<Q> = Q extends {
+	key: (params: infer P) => JSONValue;
+}
+	? P
+	: Q extends IQueryDefinition<infer P, unknown>
+	? P
+	: never;
+
+export type DataOfDefinition<Q> = Q extends IQueryDefinition<infer _, infer D>
+	? D
+	: Q extends { fetchFn: (...args: unknown[]) => Promise<infer D> }
+	? D
+	: Q extends { fetchFn: (...args: unknown[]) => infer D }
+	? D
+	: never;
+
+export interface IQueryRepository {
+	GetMaterials: IQueryDefinition<undefined, IMaterial[]>;
+	GetExchanges: IQueryDefinition<undefined, IExchange[]>;
+	GetRecipes: IQueryDefinition<undefined, IRecipe[]>;
+	GetBuildings: IQueryDefinition<undefined, IBuilding[]>;
+	GetPlanet: IQueryDefinition<{ planetNaturalId: string }, IPlanet>;
+	GetMultiplePlanets: IQueryDefinition<
 		{ planetNaturalIds: string[] },
 		IPlanet[]
 	>;
-	GetPlanetSearchSingle: QueryDefinition<{ searchId: string }, IPlanet[]>;
-	PostPlanetSearch: QueryDefinition<
+	GetPlanetSearchSingle: IQueryDefinition<{ searchId: string }, IPlanet[]>;
+	PostPlanetSearch: IQueryDefinition<
 		{ searchData: IPlanetSearchAdvanced },
 		IPlanet[]
 	>;
-	GetSharedPlan: QueryDefinition<{ sharedPlanUuid: string }, IPlanShare>;
-	GetAllShared: QueryDefinition<void, IShared[]>;
-	DeleteSharedPlan: QueryDefinition<{ sharedUuid: string }, boolean>;
-	CreateSharedPlan: QueryDefinition<
+	GetSharedPlan: IQueryDefinition<{ sharedPlanUuid: string }, IPlanShare>;
+	GetAllShared: IQueryDefinition<undefined, IShared[]>;
+	DeleteSharedPlan: IQueryDefinition<{ sharedUuid: string }, boolean>;
+	CreateSharedPlan: IQueryDefinition<
 		{ planUuid: string },
 		ISharedCreateResponse
 	>;
-	CreateEmpire: QueryDefinition<{ data: IEmpireCreatePayload }, IPlanEmpire>;
-	DeleteEmpire: QueryDefinition<{ empireUuid: string }, boolean>;
-	PatchEmpireCXJunctions: QueryDefinition<
+	CreateEmpire: IQueryDefinition<{ data: IEmpireCreatePayload }, IPlanEmpire>;
+	DeleteEmpire: IQueryDefinition<{ empireUuid: string }, boolean>;
+	PatchEmpireCXJunctions: IQueryDefinition<
 		{ junctions: ICXEmpireJunction[] },
 		ICX[]
 	>;
-	PatchCX: QueryDefinition<{ cxUuid: string; data: ICXData }, ICXData>;
-	GetAllEmpires: QueryDefinition<void, IPlanEmpireElement[]>;
-	GetEmpirePlans: QueryDefinition<{ empireUuid: string }, IPlan[]>;
-	PatchEmpire: QueryDefinition<
+	PatchCX: IQueryDefinition<{ cxUuid: string; data: ICXData }, ICXData>;
+	GetAllEmpires: IQueryDefinition<undefined, IPlanEmpireElement[]>;
+	GetEmpirePlans: IQueryDefinition<{ empireUuid: string }, IPlan[]>;
+	PatchEmpire: IQueryDefinition<
 		{ empireUuid: string; data: IEmpirePatchPayload },
 		IPlanEmpire
 	>;
-	PatchEmpirePlanJunctions: QueryDefinition<
+	PatchEmpirePlanJunctions: IQueryDefinition<
 		{ junctions: IPlanEmpireJunction[] },
 		IPlanEmpireElement[]
 	>;
-	CreateCX: QueryDefinition<{ cxName: string }, ICX>;
-	DeleteCX: QueryDefinition<{ cxUuid: string }, boolean>;
-	GetAllCX: QueryDefinition<void, ICX[]>;
-	GetPlan: QueryDefinition<{ planUuid: string }, IPlan>;
-	GetAllPlans: QueryDefinition<void, IPlan[]>;
-	ClonePlan: QueryDefinition<
+	CreateCX: IQueryDefinition<{ cxName: string }, ICX>;
+	DeleteCX: IQueryDefinition<{ cxUuid: string }, boolean>;
+	GetAllCX: IQueryDefinition<undefined, ICX[]>;
+	GetPlan: IQueryDefinition<{ planUuid: string }, IPlan>;
+	GetAllPlans: IQueryDefinition<undefined, IPlan[]>;
+	ClonePlan: IQueryDefinition<
 		{ planUuid: string; cloneName: string },
 		IPlanCloneResponse
 	>;
-	DeletePlan: QueryDefinition<{ planUuid: string }, boolean>;
-	CreatePlan: QueryDefinition<
+	DeletePlan: IQueryDefinition<{ planUuid: string }, boolean>;
+	CreatePlan: IQueryDefinition<
 		{ data: IPlanCreateData },
 		PlanSaveCreateResponseType
 	>;
-	PatchPlan: QueryDefinition<
+	PatchPlan: IQueryDefinition<
 		{ planUuid: string; data: IPlanSaveData },
 		PlanSaveCreateResponseType
 	>;
-	PatchMaterialIO: QueryDefinition<
+	PatchMaterialIO: IQueryDefinition<
 		{ data: IPlanPatchMaterialIOElement[] },
 		boolean
 	>;
-	GetExplorationData: QueryDefinition<
+	GetExplorationData: IQueryDefinition<
 		{
 			exchangeTicker: string;
 			materialTicker: string;
@@ -124,21 +149,21 @@ export type QueryRepositoryType = {
 		},
 		IExploration[]
 	>;
-	GetFIOStorage: QueryDefinition<void, IFIOStorage>;
-	GetFIOSites: QueryDefinition<void, IFIOSites>;
-	GetPlanetLastPOPR: QueryDefinition<
+	GetFIOStorage: IQueryDefinition<undefined, IFIOStorage>;
+	GetFIOSites: IQueryDefinition<undefined, IFIOSites>;
+	GetPlanetLastPOPR: IQueryDefinition<
 		{ planetNaturalId: string },
 		IPopulationReport
 	>;
-	OptimizeHabitation: QueryDefinition<
+	OptimizeHabitation: IQueryDefinition<
 		IOptimizeHabitationPayload,
 		IOptimizeHabitationResponse
 	>;
-	PatchUserProfile: QueryDefinition<IUserProfilePatch, IUserProfile>;
-	PostUserResendEmailVerification: QueryDefinition<null, boolean>;
-	PatchUserChangePassword: QueryDefinition<
+	PatchUserProfile: IQueryDefinition<IUserProfilePatch, IUserProfile>;
+	PostUserResendEmailVerification: IQueryDefinition<null, boolean>;
+	PatchUserChangePassword: IQueryDefinition<
 		IUserChangePasswordPayload,
 		boolean
 	>;
-	PostUserVerifyEmail: QueryDefinition<IUserVerifyEmailPayload, boolean>;
-};
+	PostUserVerifyEmail: IQueryDefinition<IUserVerifyEmailPayload, boolean>;
+}

--- a/src/lib/query_cache/queryStore.ts
+++ b/src/lib/query_cache/queryStore.ts
@@ -1,6 +1,6 @@
 // stores/queryStore.ts
 import { defineStore } from "pinia";
-import { reactive, computed, ComputedRef } from "vue";
+import { reactive, computed, ComputedRef, Reactive } from "vue";
 import { isSubset, toCacheKey } from "./cacheKeys";
 import { IQueryDefinition, IQueryState, JSONValue } from "./queryCache.types";
 import { useQueryRepository } from "./queryRepository";
@@ -10,395 +10,411 @@ import {
 	ParamsOfDefinition,
 } from "./queryRepository.types";
 
-export const useQueryStore = defineStore("prunplanner_query_store", () => {
-	const inFlight = new Map<string, Promise<unknown>>();
+export const useQueryStore = defineStore(
+	"prunplanner_query_store",
+	() => {
+		const inFlight = new Map<string, Promise<unknown>>();
 
-	const queryRepository = useQueryRepository();
+		const queryRepository = useQueryRepository();
 
-	const cacheState = reactive(
-		new Map<string, IQueryState<unknown, unknown>>()
-	);
+		const cacheState: Reactive<
+			Record<string, IQueryState<unknown, unknown>>
+		> = reactive({});
 
-	function $reset(): void {
-		cacheState.clear();
-		inFlight.clear();
-	}
-
-	function updateState<TParams, TData>(
-		cacheKey: string,
-		updateData: Partial<IQueryState<unknown, unknown>>
-	): void {
-		const existing = cacheState.get(cacheKey) as
-			| IQueryState<TParams, TData>
-			| undefined;
-		// update existing
-		if (existing) cacheState.set(cacheKey, { ...existing, ...updateData });
-		// set new with data
-		else
-			cacheState.set(cacheKey, {
-				definitionName: "",
-				params: null,
-				data: null,
-				loading: false,
-				error: null,
-				timestamp: 0,
-				autoRefetch: false,
-				...updateData,
-			});
-	}
-
-	function getCachedData<K extends keyof IQueryRepository>(
-		keyHash: string
-	): DataOfDefinition<IQueryRepository[K]> | null {
-		const state = cacheState.get(keyHash);
-		return state?.data as DataOfDefinition<IQueryRepository[K]> | null;
-	}
-
-	async function execute<K extends keyof IQueryRepository>(
-		definitionName: K,
-		params: ParamsOfDefinition<IQueryRepository[K]>,
-		options?: { forceRefetch?: boolean }
-	): Promise<DataOfDefinition<IQueryRepository[K]>> {
-		const definition = queryRepository.repository[
-			definitionName
-		] as IQueryDefinition<
-			ParamsOfDefinition<IQueryRepository[K]>,
-			DataOfDefinition<IQueryRepository[K]>
-		>;
-
-		const keyHash = toCacheKey(definition.key(params));
-
-		// initialize entry if missing
-		if (!cacheState.has(keyHash)) {
-			updateState(keyHash, { definitionName });
+		function deleteState(key: string) {
+			delete cacheState[key];
 		}
 
-		const state = cacheState.get(keyHash)!;
-
-		const now = Date.now();
-		const ttl = definition.expireTime;
-		const expired = ttl !== undefined && now - state.timestamp > ttl;
-		const shouldCache = definition.persist !== false;
-
-		updateState(keyHash, { expireTime: definition.expireTime });
-
-		// return cached data if valid
-		const cachedData = getCachedData<K>(keyHash);
-		if (cachedData !== null && !options?.forceRefetch && !expired) {
-			return cachedData;
+		function $reset(): void {
+			Object.keys(cacheState).forEach((key) => delete cacheState[key]);
+			inFlight.clear();
 		}
 
-		// return in-flight promise if exists
-		if (inFlight.has(keyHash) && !options?.forceRefetch) {
-			return inFlight.get(keyHash)! as Promise<
+		function updateState<TParams, TData>(
+			cacheKey: string,
+			updateData: Partial<IQueryState<unknown, unknown>>
+		): void {
+			const existing = cacheState[cacheKey] as
+				| IQueryState<TParams, TData>
+				| undefined;
+			// update existing
+			if (existing) cacheState[cacheKey] = { ...existing, ...updateData };
+			// set new with data
+			else
+				cacheState[cacheKey] = {
+					definitionName: "",
+					params: null,
+					data: null,
+					loading: false,
+					error: null,
+					timestamp: 0,
+					autoRefetch: false,
+					...updateData,
+				};
+		}
+
+		function getCachedData<K extends keyof IQueryRepository>(
+			keyHash: string
+		): DataOfDefinition<IQueryRepository[K]> | null {
+			const state = cacheState[keyHash];
+			return state?.data as DataOfDefinition<IQueryRepository[K]> | null;
+		}
+
+		async function execute<K extends keyof IQueryRepository>(
+			definitionName: K,
+			params: ParamsOfDefinition<IQueryRepository[K]>,
+			options?: { forceRefetch?: boolean }
+		): Promise<DataOfDefinition<IQueryRepository[K]>> {
+			const definition = queryRepository.repository[
+				definitionName
+			] as IQueryDefinition<
+				ParamsOfDefinition<IQueryRepository[K]>,
 				DataOfDefinition<IQueryRepository[K]>
 			>;
-		}
 
-		// mark as loading
-		updateState(keyHash, {
-			params: params ?? undefined,
-			loading: true,
-			error: null,
-			autoRefetch: definition.autoRefetch,
-		});
+			const keyHash = toCacheKey(definition.key(params));
 
-		const promise = (async () => {
-			try {
-				const result: DataOfDefinition<IQueryRepository[K]> =
-					await definition.fetchFn(
-						params as ParamsOfDefinition<IQueryRepository[K]>
-					);
-
-				if (shouldCache) {
-					updateState(keyHash, {
-						data: result,
-						timestamp: Date.now(),
-					});
-				}
-
-				return result as DataOfDefinition<IQueryRepository[K]>;
-			} catch (err) {
-				updateState(keyHash, {
-					error: err instanceof Error ? err : new Error(String(err)),
-					timestamp: Date.now(),
-				});
-				console.error(err);
-				throw err;
-			} finally {
-				updateState(keyHash, { loading: false });
-				inFlight.delete(keyHash);
-				if (!shouldCache) cacheState.delete(keyHash);
+			// initialize entry if missing
+			if (!cacheState[keyHash]) {
+				updateState(keyHash, { definitionName });
 			}
-		})();
 
-		inFlight.set(keyHash, promise);
-
-		return promise as Promise<DataOfDefinition<IQueryRepository[K]>>;
-	}
-
-	/**
-	 * Peaks a queries state readonly without ever creating it on call.
-	 * Will take into account existance as well as "fresh" state, will
-	 * return undefined if the state is not existing or stale.
-	 *
-	 * @author jplacht
-	 *
-	 * @readonly
-	 * @template TParams Query Params Type
-	 * @template TData Query Data Type
-	 * @param {JSONValue} key Query Key
-	 * @returns {(QueryState<TParams, TData> | undefined)} QueryState or Undefined
-	 */
-	function peekQueryState<TParams, TData>(
-		key: JSONValue
-	): IQueryState<TParams, TData> | undefined {
-		return isKnownAndFresh(key).value
-			? (cacheState.get(toCacheKey(key)) as IQueryState<TParams, TData>)
-			: undefined;
-	}
-
-	/**
-	 * Checks a given query key for existance and if still fresh.
-	 * Freshness is given if:
-	 * - Key must exist
-	 * - Key does not have an expiry time, it is always fresh
-	 * - Or key has an expiry time that is still valid now
-	 *
-	 * @author jplacht
-	 *
-	 * @param {JSONValue} key Query Key
-	 * @returns {ComputedRef<boolean>} Existing and fresh state
-	 */
-	function isKnownAndFresh(key: JSONValue): ComputedRef<boolean> {
-		return computed(() => {
-			const keyHash: string = toCacheKey(key);
-			const state = cacheState.get(keyHash);
-
-			// state is undefined => false
-			if (!state) return false;
-
-			// state is known
-			// if no expireTime, its fresh => true
-			if (!state.expireTime) return true;
-
-			// check the expire time
+			const state = cacheState[keyHash]!;
 
 			const now = Date.now();
-			const expired = now - state.timestamp > state.expireTime;
+			const ttl = definition.expireTime;
+			const expired = ttl !== undefined && now - state.timestamp > ttl;
+			const shouldCache = definition.persist !== false;
 
-			if (expired) {
-				return false;
-			} else {
-				return true;
+			updateState(keyHash, { expireTime: definition.expireTime });
+
+			// return cached data if valid
+			const cachedData = getCachedData<K>(keyHash);
+			if (cachedData !== null && !options?.forceRefetch && !expired) {
+				return cachedData;
 			}
-		});
-	}
 
-	/**
-	 * Invalidates given key in the store
-	 *
-	 * @author jplacht
-	 *
-	 * @async
-	 * @template TParams Query Params Type
-	 * @template TData Query Data Type
-	 * @param {JSONValue} key Query Key
-	 * @param {{ exact?: boolean; forceRefetch?: boolean; skipRefetch?: boolean }} [options={
-	 * 			exact: true,
-	 * 			forceRefetch: false,
-	 * 			skipRefetch: false,
-	 * 		}] Options, by default will check for exact matches and doesn't force refresh
-	 * @returns {Promise<void>}
-	 */
-	async function invalidateKey<K extends keyof IQueryRepository, TParams>(
-		key: JSONValue,
-		options: {
-			exact?: boolean;
-			forceRefetch?: boolean;
-			skipRefetch?: boolean;
-		} = {
-			exact: true,
-			forceRefetch: false,
-			skipRefetch: false,
+			// return in-flight promise if exists
+			if (inFlight.has(keyHash) && !options?.forceRefetch) {
+				return inFlight.get(keyHash)! as Promise<
+					DataOfDefinition<IQueryRepository[K]>
+				>;
+			}
+
+			// mark as loading
+			updateState(keyHash, {
+				params: params ?? undefined,
+				loading: true,
+				error: null,
+				autoRefetch: definition.autoRefetch,
+			});
+
+			const promise = (async () => {
+				try {
+					const result: DataOfDefinition<IQueryRepository[K]> =
+						await definition.fetchFn(
+							params as ParamsOfDefinition<IQueryRepository[K]>
+						);
+
+					if (shouldCache) {
+						updateState(keyHash, {
+							data: result,
+							timestamp: Date.now(),
+						});
+					}
+
+					return result as DataOfDefinition<IQueryRepository[K]>;
+				} catch (err) {
+					updateState(keyHash, {
+						error:
+							err instanceof Error ? err : new Error(String(err)),
+						timestamp: Date.now(),
+					});
+					console.error(err);
+					throw err;
+				} finally {
+					updateState(keyHash, { loading: false });
+					inFlight.delete(keyHash);
+					if (!shouldCache) deleteState(keyHash);
+				}
+			})();
+
+			inFlight.set(keyHash, promise);
+
+			return promise as Promise<DataOfDefinition<IQueryRepository[K]>>;
 		}
-	): Promise<void> {
-		const keyHash: string = toCacheKey(key);
 
-		const toRefetch: {
-			definitionKey: K;
-			params: TParams | null;
-		}[] = [];
+		/**
+		 * Peaks a queries state readonly without ever creating it on call.
+		 * Will take into account existance as well as "fresh" state, will
+		 * return undefined if the state is not existing or stale.
+		 *
+		 * @author jplacht
+		 *
+		 * @readonly
+		 * @template TParams Query Params Type
+		 * @template TData Query Data Type
+		 * @param {JSONValue} key Query Key
+		 * @returns {(QueryState<TParams, TData> | undefined)} QueryState or Undefined
+		 */
+		function peekQueryState<TParams, TData>(
+			key: JSONValue
+		): IQueryState<TParams, TData> | undefined {
+			return isKnownAndFresh(key).value
+				? (cacheState[toCacheKey(key)] as IQueryState<TParams, TData>)
+				: undefined;
+		}
 
-		if (options.exact) {
-			if (cacheState.has(keyHash)) {
-				const existingEntry = cacheState.get(keyHash)!;
+		/**
+		 * Checks a given query key for existance and if still fresh.
+		 * Freshness is given if:
+		 * - Key must exist
+		 * - Key does not have an expiry time, it is always fresh
+		 * - Or key has an expiry time that is still valid now
+		 *
+		 * @author jplacht
+		 *
+		 * @param {JSONValue} key Query Key
+		 * @returns {ComputedRef<boolean>} Existing and fresh state
+		 */
+		function isKnownAndFresh(key: JSONValue): ComputedRef<boolean> {
+			return computed(() => {
+				const keyHash: string = toCacheKey(key);
+				const state = cacheState[keyHash];
 
-				toRefetch.push({
-					definitionKey: existingEntry.definitionName as K,
-					params: existingEntry.params as TParams | null,
-				});
+				// state is undefined => false
+				if (!state) return false;
+
+				// state is known
+				// if no expireTime, its fresh => true
+				if (!state.expireTime) return true;
+
+				// check the expire time
+
+				const now = Date.now();
+				const expired = now - state.timestamp > state.expireTime;
+
+				if (expired) {
+					return false;
+				} else {
+					return true;
+				}
+			});
+		}
+
+		/**
+		 * Invalidates given key in the store
+		 *
+		 * @author jplacht
+		 *
+		 * @async
+		 * @template TParams Query Params Type
+		 * @template TData Query Data Type
+		 * @param {JSONValue} key Query Key
+		 * @param {{ exact?: boolean; forceRefetch?: boolean; skipRefetch?: boolean }} [options={
+		 * 			exact: true,
+		 * 			forceRefetch: false,
+		 * 			skipRefetch: false,
+		 * 		}] Options, by default will check for exact matches and doesn't force refresh
+		 * @returns {Promise<void>}
+		 */
+		async function invalidateKey<K extends keyof IQueryRepository, TParams>(
+			key: JSONValue,
+			options: {
+				exact?: boolean;
+				forceRefetch?: boolean;
+				skipRefetch?: boolean;
+			} = {
+				exact: true,
+				forceRefetch: false,
+				skipRefetch: false,
 			}
+		): Promise<void> {
+			const keyHash: string = toCacheKey(key);
 
-			// delete exact matched key and inflight
-			cacheState.delete(keyHash);
-			inFlight.delete(keyHash);
-		} else {
-			for (const existingKey of cacheState.keys()) {
-				// Note: as keys are strings, need to parse them to JSONValue
-				if (isSubset(key, JSON.parse(existingKey) as JSONValue)) {
-					// add subset query
-					const existingEntry = cacheState.get(existingKey)!;
+			const toRefetch: {
+				definitionKey: K;
+				params: TParams | null;
+			}[] = [];
+
+			if (options.exact) {
+				const existingEntry = cacheState[keyHash];
+				if (existingEntry) {
 					toRefetch.push({
 						definitionKey: existingEntry.definitionName as K,
 						params: existingEntry.params as TParams | null,
 					});
+				}
 
-					// delete non-exact matched key and inflight
-					cacheState.delete(existingKey);
-					inFlight.delete(keyHash);
+				// delete exact matched key and inflight
+				deleteState(keyHash);
+				inFlight.delete(keyHash);
+			} else {
+				for (const existingKey of Object.keys(cacheState)) {
+					// Note: as keys are strings, need to parse them to JSONValue
+					if (isSubset(key, JSON.parse(existingKey) as JSONValue)) {
+						// add subset query
+						const existingEntry = cacheState[existingKey];
+						toRefetch.push({
+							definitionKey: existingEntry.definitionName as K,
+							params: existingEntry.params as TParams | null,
+						});
+
+						// delete non-exact matched key and inflight
+						deleteState(existingKey);
+						inFlight.delete(existingKey);
+					}
 				}
 			}
-		}
 
-		// check and trigger refetches if defined or forced
-		toRefetch.map(async (refetchEntry) => {
-			// get definition
-			const definition: IQueryRepository[K] =
-				queryRepository.repository[refetchEntry.definitionKey];
-			// refetch can be forced from invalidate options or set
-			// in the query definition itself
+			// check and trigger refetches if defined or forced
+			toRefetch.map(async (refetchEntry) => {
+				// get definition
+				const definition: IQueryRepository[K] =
+					queryRepository.repository[refetchEntry.definitionKey];
+				// refetch can be forced from invalidate options or set
+				// in the query definition itself
 
-			if (
-				!options.skipRefetch &&
-				(options.forceRefetch || definition!.autoRefetch)
-			) {
-				// if params are null, no params required, pass undefined
-				await execute(
-					refetchEntry.definitionKey as K,
-					refetchEntry.params as ParamsOfDefinition<
-						IQueryRepository[K]
-					>
-				);
-			}
-		});
-	}
-
-	/**
-	 * Allows manually creating a cache state
-	 *
-	 * @author jplacht
-	 *
-	 * @async
-	 * @template TParams Params
-	 * @template TData Data
-	 * @param {JSONValue} key Key Value
-	 * @param {QueryDefinition<TParams, TData>} definition Query Definition
-	 * @param {TParams} params Query Params
-	 * @param {TData} data Result Data
-	 * @returns {Promise<void>} void
-	 */
-	async function addCacheState<
-		K extends keyof IQueryRepository,
-		TParams,
-		TData
-	>(
-		key: JSONValue,
-		definitionName: K,
-		params: TParams,
-		data: TData
-	): Promise<void> {
-		const keyHash: string = toCacheKey(key);
-		// identify correct definition
-		const definition: IQueryRepository[K] =
-			queryRepository.repository[definitionName];
-
-		// do not overwrite existing state for key
-		if (!cacheState.get(keyHash)) {
-			updateState(keyHash, {
-				definitionName,
-				params: params,
-				data: data,
-				loading: false,
-				error: null,
-				timestamp: Date.now(),
-				expireTime: definition.expireTime,
+				if (
+					!options.skipRefetch &&
+					(options.forceRefetch || definition!.autoRefetch)
+				) {
+					// if params are null, no params required, pass undefined
+					await execute(
+						refetchEntry.definitionKey as K,
+						refetchEntry.params as ParamsOfDefinition<
+							IQueryRepository[K]
+						>
+					);
+				}
 			});
 		}
-	}
 
-	/**
-	 * True, if any cache state is currently loading
-	 * @author jplacht
-	 *
-	 * @type {ComputedRef<boolean>}
-	 */
-	const isAnythingLoading: ComputedRef<boolean> = computed(() =>
-		Array.from(cacheState.values()).some((s) => s.loading)
-	);
+		/**
+		 * Allows manually creating a cache state
+		 *
+		 * @author jplacht
+		 *
+		 * @async
+		 * @template TParams Params
+		 * @template TData Data
+		 * @param {JSONValue} key Key Value
+		 * @param {QueryDefinition<TParams, TData>} definition Query Definition
+		 * @param {TParams} params Query Params
+		 * @param {TData} data Result Data
+		 * @returns {Promise<void>} void
+		 */
+		async function addCacheState<
+			K extends keyof IQueryRepository,
+			TParams,
+			TData
+		>(
+			key: JSONValue,
+			definitionName: K,
+			params: TParams,
+			data: TData
+		): Promise<void> {
+			const keyHash: string = toCacheKey(key);
+			// identify correct definition
+			const definition: IQueryRepository[K] =
+				queryRepository.repository[definitionName];
 
-	// Regular status watcher
-	let intervalId: ReturnType<typeof setInterval> | null = null;
+			// do not overwrite existing state for key
+			if (!cacheState[keyHash]) {
+				updateState(keyHash, {
+					definitionName,
+					params: params,
+					data: data,
+					loading: false,
+					error: null,
+					timestamp: Date.now(),
+					expireTime: definition.expireTime,
+				});
+			}
+		}
 
-	/**
-	 * Iterates over cache entries and triggers refresh if
-	 * marked as to be automatically refetched
-	 *
-	 * @author jplacht
-	 */
-	function checkEntryStatusAndRefresh<K extends keyof IQueryRepository>() {
-		const now = Date.now();
+		/**
+		 * True, if any cache state is currently loading
+		 * @author jplacht
+		 *
+		 * @type {ComputedRef<boolean>}
+		 */
+		const isAnythingLoading: ComputedRef<boolean> = computed(() =>
+			Object.values(cacheState).some((s) => s.loading)
+		);
 
-		for (const [key, entry] of cacheState.entries()) {
-			if (
-				entry.expireTime &&
-				!entry.loading &&
-				entry.error === null &&
-				now - entry.timestamp > entry.expireTime
-			) {
-				// identify correct definition
-				const definition: IQueryRepository[K] =
-					queryRepository.repository[entry.definitionName as K];
+		// Regular status watcher
+		let intervalId: ReturnType<typeof setInterval> | null = null;
 
-				if (definition.autoRefetch) {
-					execute(
-						entry.definitionName as K,
-						entry.params as ParamsOfDefinition<IQueryRepository[K]>
-					);
-				} else {
-					// delete as stale and should not refetch
-					invalidateKey(JSON.parse(key) as JSONValue);
+		/**
+		 * Iterates over cache entries and triggers refresh if
+		 * marked as to be automatically refetched
+		 *
+		 * @author jplacht
+		 */
+		function checkEntryStatusAndRefresh<
+			K extends keyof IQueryRepository
+		>() {
+			const now = Date.now();
+
+			for (const [key, entry] of Object.entries(cacheState)) {
+				if (
+					entry.expireTime &&
+					!entry.loading &&
+					entry.error === null &&
+					now - entry.timestamp > entry.expireTime
+				) {
+					// identify correct definition
+					const definition: IQueryRepository[K] =
+						queryRepository.repository[entry.definitionName as K];
+
+					if (definition.autoRefetch) {
+						execute(
+							entry.definitionName as K,
+							entry.params as ParamsOfDefinition<
+								IQueryRepository[K]
+							>
+						);
+					} else {
+						// delete as stale and should not refetch
+						invalidateKey(JSON.parse(key) as JSONValue);
+					}
 				}
 			}
 		}
+
+		/**
+		 * Starts the entry status watcher, prevents multiple watchers
+		 * to be running in parallel.
+		 *
+		 * @author jplacht
+		 */
+		function startStatusWatcher() {
+			// prevent multiple invervals running
+			if (intervalId !== null) return;
+
+			intervalId = setInterval(() => checkEntryStatusAndRefresh(), 1000);
+		}
+
+		// start the status watcher
+		startStatusWatcher();
+
+		return {
+			$reset,
+			cacheState,
+			peekQueryState,
+			execute,
+			invalidateKey,
+			addCacheState,
+			isAnythingLoading,
+			// only exposed for testing
+			checkEntryStatusAndRefresh,
+			startStatusWatcher,
+		};
+	},
+	{
+		persist: {
+			pick: ["cacheState"],
+		},
 	}
-
-	/**
-	 * Starts the entry status watcher, prevents multiple watchers
-	 * to be running in parallel.
-	 *
-	 * @author jplacht
-	 */
-	function startStatusWatcher() {
-		// prevent multiple invervals running
-		if (intervalId !== null) return;
-
-		intervalId = setInterval(() => checkEntryStatusAndRefresh(), 1000);
-	}
-
-	// start the status watcher
-	startStatusWatcher();
-
-	return {
-		$reset,
-		cacheState,
-		peekQueryState,
-		execute,
-		invalidateKey,
-		addCacheState,
-		isAnythingLoading,
-		// only exposed for testing
-		checkEntryStatusAndRefresh,
-		startStatusWatcher,
-	};
-});
+);

--- a/src/lib/query_cache/queryStore.ts
+++ b/src/lib/query_cache/queryStore.ts
@@ -1,4 +1,3 @@
-// stores/queryStore.ts
 import { defineStore } from "pinia";
 import { reactive, computed, ComputedRef, Reactive } from "vue";
 import { isSubset, toCacheKey } from "./cacheKeys";

--- a/src/lib/query_cache/queryStore.ts
+++ b/src/lib/query_cache/queryStore.ts
@@ -416,5 +416,10 @@ export const useQueryStore = defineStore(
 		persist: {
 			pick: ["cacheState"],
 		},
+		broadcastWatch: {
+			pick: ["cacheState"],
+			debounce: 500,
+			channel: "pinia_query_cache",
+		},
 	}
 );

--- a/src/main.ts
+++ b/src/main.ts
@@ -5,9 +5,11 @@ import AppProvider from "@/AppProvider.vue";
 // stores
 import { createPinia } from "pinia";
 import piniaPluginPersistedstate from "pinia-plugin-persistedstate";
+import { createBroadcastChannelDiffPlugin } from "@/lib/piniaLocalStorageWatcher";
 
 const pinia = createPinia();
 pinia.use(piniaPluginPersistedstate);
+pinia.use(createBroadcastChannelDiffPlugin());
 
 // routing
 import router from "@/router";
@@ -21,7 +23,6 @@ app.use(pinia);
 
 // axios
 import axiosSetup from "@/util/axiosSetup";
-
 axiosSetup();
 
 // highcharts

--- a/src/main.ts
+++ b/src/main.ts
@@ -5,11 +5,11 @@ import AppProvider from "@/AppProvider.vue";
 // stores
 import { createPinia } from "pinia";
 import piniaPluginPersistedstate from "pinia-plugin-persistedstate";
-import { createBroadcastChannelDiffPlugin } from "@/lib/piniaLocalStorageWatcher";
+import { createBroadcastChannelPlugin } from "@/lib/piniaBroadcastChannelPlugin";
 
 const pinia = createPinia();
 pinia.use(piniaPluginPersistedstate);
-pinia.use(createBroadcastChannelDiffPlugin());
+pinia.use(createBroadcastChannelPlugin());
 
 // routing
 import router from "@/router";

--- a/src/stores/gameDataStore.ts
+++ b/src/stores/gameDataStore.ts
@@ -253,5 +253,20 @@ export const useGameDataStore = defineStore(
 				"fio_sites_ships",
 			],
 		},
+		broadcastWatch: {
+			pick: [
+				"materials",
+				"exchanges",
+				"recipes",
+				"buildings",
+				"planets",
+				"fio_storage_planets",
+				"fio_storage_warehouses",
+				"fio_storage_ships",
+				"fio_sites_planets",
+				"fio_sites_ships",
+			],
+			channel: "pinia_game_data",
+		},
 	}
 );

--- a/src/stores/planningStore.ts
+++ b/src/stores/planningStore.ts
@@ -220,5 +220,9 @@ export const usePlanningStore = defineStore(
 		persist: {
 			pick: ["plans", "empires", "cxs", "shared"],
 		},
+		broadcastWatch: {
+			pick: ["plans", "empires", "cxs", "shared"],
+			channel: "pinia_planning_data",
+		},
 	}
 );

--- a/src/stores/planningStore.ts
+++ b/src/stores/planningStore.ts
@@ -107,7 +107,7 @@ export const usePlanningStore = defineStore(
 		}
 
 		function setCX(cxUuid: string, data: ICXData): void {
-			cxs.value[cxUuid].cx_data = data;
+			if (cxs.value[cxUuid]) cxs.value[cxUuid].cx_data = data;
 		}
 
 		/**

--- a/src/tests/stores/planningStore.test.ts
+++ b/src/tests/stores/planningStore.test.ts
@@ -63,6 +63,19 @@ describe("Planning Store", async () => {
 			expect(result.length).toBe(cx_list.length);
 		});
 
+		it("setCX", async () => {
+			planningStore.$reset();
+
+			// can't set as not existis
+			planningStore.setCX(cx_list[0].uuid, cx_list[0].cx_data);
+			expect(Object.keys(planningStore.cxs).length).toBe(0);
+
+			planningStore.setCXs([cx_list[0]]);
+			expect(Object.keys(planningStore.cxs).length).toBe(1);
+			planningStore.setCX(cx_list[0].uuid, cx_list[0].cx_data);
+			expect(Object.keys(planningStore.cxs).length).toBe(1);
+		});
+
 		it("getCX", async () => {
 			planningStore.setCXs(cx_list);
 			expect(

--- a/src/ui/components/PInputNumber.vue
+++ b/src/ui/components/PInputNumber.vue
@@ -2,9 +2,9 @@
 	import { SizeKey } from "@/ui/ui.types";
 	import { inputNumberConfig } from "@/ui/styles";
 
-	const value = defineModel<number>("value", {
+	const value = defineModel<number | null>("value", {
 		required: true,
-		type: Number,
+		type: [Number, null],
 	});
 
 	const {
@@ -36,13 +36,17 @@
 
 	function canChange(e: number): boolean {
 		if (disabled) return false;
+		if (value.value === null) value.value = 0;
 
 		if (value.value + e >= min && value.value + e <= max) return true;
 		return false;
 	}
 
 	function change(e: number) {
-		if (canChange(e)) value.value += e;
+		if (canChange(e)) {
+			if (value.value === null) value.value = 0;
+			value.value += e;
+		}
 	}
 </script>
 

--- a/src/views/EmpireView.vue
+++ b/src/views/EmpireView.vue
@@ -15,6 +15,7 @@
 	});
 
 	// Composables
+	import { useQuery } from "@/lib/query_cache/useQuery";
 	import { usePlanCalculation } from "@/features/planning/usePlanCalculation";
 	import { useMaterialIOUtil } from "@/features/planning/util/materialIO.util";
 	import { usePreferences } from "@/features/preferences/usePreferences";
@@ -55,8 +56,6 @@
 
 	// UI
 	import { PForm, PFormItem, PSelect } from "@/ui";
-	import { useQuery } from "@/lib/query_cache/useQuery";
-	import { useQueryRepository } from "@/lib/query_cache/queryRepository";
 
 	const props = defineProps({
 		empireUuid: {
@@ -116,9 +115,7 @@
 	async function reloadEmpires(): Promise<void> {
 		try {
 			// make a forced call to also update store
-			refEmpireList.value = await useQuery(
-				useQueryRepository().repository.GetAllEmpires
-			).execute();
+			refEmpireList.value = await useQuery("GetAllEmpires").execute();
 		} catch (err) {
 			console.error("Error reloading empires", err);
 		}

--- a/src/views/ExchangesView.vue
+++ b/src/views/ExchangesView.vue
@@ -13,7 +13,6 @@
 
 	// Composables
 	import { useQuery } from "@/lib/query_cache/useQuery";
-	import { useQueryRepository } from "@/lib/query_cache/queryRepository";
 	import { usePostHog } from "@/lib/usePostHog";
 	const { capture } = usePostHog();
 
@@ -156,7 +155,7 @@
 
 			capture("exchange_patch", { exchangeUuid: selectedCX.value.uuid });
 
-			await useQuery(useQueryRepository().repository.PatchCX, {
+			await useQuery("PatchCX", {
 				cxUuid: selectedCX.value.uuid,
 				data: data,
 			}).execute();

--- a/src/views/tools/HQUpgradeCalculatorView.vue
+++ b/src/views/tools/HQUpgradeCalculatorView.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-	import { Ref, ref } from "vue";
+	import { computed, Ref, ref } from "vue";
 	import { useHead } from "@unhead/vue";
 
 	useHead({
@@ -32,6 +32,13 @@
 	const selectedOverride: Ref<Record<string, number | null>> = ref({});
 	const selectedShowLocations: Ref<boolean> = ref(true);
 	const refSelectedCXUuid: Ref<string | undefined> = ref(undefined);
+
+	function overrideBinding(ticker: string) {
+		return computed({
+			get: () => selectedOverride.value[ticker] ?? null,
+			set: (val) => (selectedOverride.value[ticker] = val),
+		});
+	}
 
 	const {
 		levelOptions,
@@ -180,7 +187,7 @@
 								<PInputNumber
 									:key="`OVERRIDE#${rowData.ticker}`"
 									v-model:value="
-										selectedOverride[rowData.ticker]!
+										overrideBinding(rowData.ticker).value
 									"
 									:min="0"
 									clearable

--- a/src/views/tools/market-data/MarketExplorationView.vue
+++ b/src/views/tools/market-data/MarketExplorationView.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-	import { Ref, ref } from "vue";
+	import { Ref, ref, ComputedRef, computed } from "vue";
 	import { useHead } from "@unhead/vue";
 
 	useHead({
@@ -37,7 +37,7 @@
 		})
 	);
 
-	const materialOptions: Ref<PSelectOption[]> = ref(
+	const materialOptions: ComputedRef<PSelectOption[]> = computed(() =>
 		gameDataStore.getMaterials().map((e) => {
 			return { label: e.Ticker, value: e.Ticker };
 		})

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -36,6 +36,7 @@ export default defineConfig({
 				"**/QueryCacheView.vue",
 				"src/features/wrapper/**",
 				"src/util/axiosSetup.ts",
+				"src/lib/piniaBroadcastChannelPlugin.ts",
 			],
 			reportOnFailure: true,
 		},


### PR DESCRIPTION
This PR does the following changes:

- Interacting with the Backend API is now Key-based. Instead of getting a full definition from the repository and storing it incl. its function calls, each query state is now solely data based, allowing it to be properly persisted in localStorage
- Game Data, Planning Data and Query Data is now broadcasted across users open tabs to keep static data in sync
- Fixes a small isue in HQ Upgrade Calculation where not initialized overwrites would fail on PInputNumber