### PR TITLE
improve(versioncheck): skip if user is not logged in

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -42,7 +42,7 @@
 </script>
 
 <template>
-	<VersionUpdateNotification v-if="updateAvailable" />
+	<VersionUpdateNotification v-if="updateAvailable && userStore.isLoggedIn" />
 
 	<main class="flex h-view w-full bg-[rgb(3,7,7)] text-white/80">
 		<template v-if="userStore.isLoggedIn">

--- a/src/assets/help/changelog.md
+++ b/src/assets/help/changelog.md
@@ -1,3 +1,7 @@
+# 2025-08-26
+
+- Skip Version frontend version check if user is not logged in, set current version on login [#205](https://github.com/PRUNplanner/frontend/issues/205)
+
 # 2025-08-25
 
 - Updates to ROI and Resource ROI Overview Help texts (by `lowstrife`)

--- a/src/lib/useVersionCheck.ts
+++ b/src/lib/useVersionCheck.ts
@@ -16,6 +16,9 @@ const LOCAL_KEY = "prunplanner_version";
 
 export function useVersionCheck(interval = 60_000) {
 	const checkVersion = async () => {
+		// skip on dev mode
+		if (import.meta.env.DEV) return;
+
 		try {
 			const res = await fetch("/version.json", { cache: "no-cache" });
 			const data = await res.json();
@@ -41,6 +44,9 @@ export function useVersionCheck(interval = 60_000) {
 	};
 
 	async function markUpdated(): Promise<void> {
+		// skip on dev mode
+		if (import.meta.env.DEV) return;
+
 		const res = await fetch("/version.json", { cache: "no-cache" });
 		const data = await res.json();
 		const latestVersion = data.version;

--- a/src/stores/userStore.ts
+++ b/src/stores/userStore.ts
@@ -16,6 +16,7 @@ import { useQueryStore } from "@/lib/query_cache/queryStore";
 
 // Composables
 import { usePostHog } from "@/lib/usePostHog";
+import { useVersionCheck } from "@/lib/useVersionCheck";
 
 // Types & Interfaces
 import {
@@ -156,6 +157,10 @@ export const useUserStore = defineStore(
 				);
 
 				setToken(tokenData.access_token, tokenData.refresh_token);
+
+				// sets the current version to the available version
+				const { markUpdated } = useVersionCheck();
+				await markUpdated();
 
 				return true;
 			} catch (err) {

--- a/src/tests/lib/useVersionCheck.test.ts
+++ b/src/tests/lib/useVersionCheck.test.ts
@@ -14,6 +14,8 @@ describe("useVersionCheck", () => {
 			removeItem: vi.fn(),
 		});
 
+		vi.stubEnv("DEV", false);
+
 		currentVersion.value = null;
 		updateAvailable.value = false;
 	});


### PR DESCRIPTION
Skips Notification if user is not logged in, prevents version to be set in Vite DEV mode, sets the current version on user login.

close #205 