### PR TITLE
Fix for COGC Name

### DIFF
--- a/src/features/planet_search/usePlanetSearchResults.ts
+++ b/src/features/planet_search/usePlanetSearchResults.ts
@@ -100,7 +100,7 @@ export function usePlanetSearchResults(
 			const infrastructures: string[] = [];
 
 			if (e.HasLocalMarket) infrastructures.push("LM");
-			if (e.HasChamberOfCommerce) infrastructures.push("COGM");
+			if (e.HasChamberOfCommerce) infrastructures.push("COGC");
 			if (e.HasWarehouse) infrastructures.push("WAR");
 			if (e.HasAdministrationCenter) infrastructures.push("ADM");
 			if (e.HasShipyard) infrastructures.push("SHY");


### PR DESCRIPTION
Currently shows COGM when a Chamber of Global Commerce is built on a planet, should show COGC