### PR TITLE
UI tweaks

### DIFF
--- a/src/features/xit/components/XITTransferActionButton.vue
+++ b/src/features/xit/components/XITTransferActionButton.vue
@@ -109,14 +109,17 @@
 						:options="XITSTATIONWAREHOUSES" />
 				</PFormItem>
 				<PFormItem label="Buy From CX">
-					<PCheckbox
-						v-model:checked="defaultBuyItemsFromCX"
-						:disabled="burnOrigin === 'Configure on Execution'" />
+					<div class="w-full flex flex-row gap-1 my-3 h-[32px] items-center">
+						<PCheckbox
+							v-model:checked="defaultBuyItemsFromCX"
+							:disabled="burnOrigin === 'Configure on Execution'" />
 
-					<div
-						v-if="burnOrigin === 'Configure on Execution'"
-						class="p-3">
-						Requires origin warehouse to purchase
+						<div
+							v-if="burnOrigin === 'Configure on Execution'"
+							class="pl-3 text-xs text-white/50"
+							>
+							Requires origin warehouse to purchase
+						</div>
 					</div>
 				</PFormItem>
 				<PFormItem label="JSON">

--- a/src/ui/components/PCheckbox.vue
+++ b/src/ui/components/PCheckbox.vue
@@ -1,31 +1,34 @@
 <script setup lang="ts">
+	import { computed } from "vue";
+
 	import { checkboxConfig } from "@/ui/styles";
 	const checked = defineModel<boolean>("checked");
 
 	const { disabled = false } = defineProps<{ disabled?: boolean }>();
+
+	const inputBase = computed(() =>
+		[
+			checkboxConfig.input,
+			checkboxConfig.colors.base,
+			checkboxConfig.colors.disabled,
+		].join(" ")
+	);
 </script>
 
 <template>
 	<div class="pcheckbox" :class="checkboxConfig.container">
-		<label
-			:class="
-				!disabled
-					? checkboxConfig.label
-					: `${checkboxConfig.label} !cursor-auto`
-			">
+		<label :class="checkboxConfig.label" >
 			<input
 				v-model="checked"
 				:disabled="disabled"
 				type="checkbox"
-				:class="checkboxConfig.input" />
+				:class="inputBase" />
 			<span :class="checkboxConfig.checkIcon">
 				<svg
 					xmlns="http://www.w3.org/2000/svg"
 					:class="checkboxConfig.checkIconSVG"
 					viewBox="0 0 20 20"
-					fill="currentColor"
-					stroke="currentColor"
-					stroke-width="1">
+					>
 					<path
 						fill-rule="evenodd"
 						d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z"

--- a/src/ui/components/PFormItem.vue
+++ b/src/ui/components/PFormItem.vue
@@ -10,7 +10,7 @@
 	<div :class="formItemConfig.content">
 		<slot />
 	</div>
-	<div v-if="$slots.info" class="col-2 pb-1 text-[10px] text-white/50">
+	<div v-if="$slots.info" class="col-2 pb-1 text-xs text-white/50">
 		<slot name="info" />
 	</div>
 </template>

--- a/src/ui/styles.ts
+++ b/src/ui/styles.ts
@@ -11,7 +11,7 @@ import {
 } from "@/ui/ui.types";
 
 export const buttonConfig: PButtonConfig = {
-	base: "flex flex-row items-center justify-center leading-none rounded-sm child:cursor-pointer cursor-pointer text-nowrap",
+	base: "flex flex-row items-center justify-center leading-none rounded-sm cursor-pointer disabled:cursor-auto text-nowrap",
 	defaultSize: "md",
 	defaultColor: "primary",
 	sizes: {
@@ -31,31 +31,31 @@ export const buttonConfig: PButtonConfig = {
 			base: "bg-blue-800 text-white active:bg-blue-600",
 			hover: "hover:bg-blue-700",
 			disabled:
-				"disabled:bg-blue-800/50 disabled:text-white/80 !cursor-auto",
+				"disabled:bg-blue-800/50 disabled:text-white/80",
 		},
 		success: {
 			base: "bg-lime-500 text-black active:bg-lime-300",
 			hover: "hover:bg-lime-400",
 			disabled:
-				"disabled:bg-lime-500/50 disabled:text-white/80 !cursor-auto",
+				"disabled:bg-lime-500/50 disabled:text-white/80",
 		},
 		secondary: {
 			base: "bg-gray-800 text-white active:bg-gray-600",
 			hover: "hover:bg-gray-700",
 			disabled:
-				"disabled:bg-gray-800/50 disabled:text-white/80 !cursor-auto",
+				"disabled:bg-gray-800/50 disabled:text-white/80",
 		},
 		error: {
 			base: "bg-red-600 text-white active:bg-red-500",
 			hover: "hover:bg-red-700",
 			disabled:
-				"disabled:bg-red-600/50 disabled:text-white/80 !cursor-auto",
+				"disabled:bg-red-600/50 disabled:text-white/80",
 		},
 		warning: {
 			base: "bg-gray-100 text-gray-900 active:bg-gray-300",
 			hover: "hover:bg-gray-200",
 			disabled:
-				"disabled:bg-gray-100/50 disabled:text-gray-900 !cursor-auto",
+				"disabled:bg-gray-100/50 disabled:text-gray-900",
 		},
 	},
 };

--- a/src/ui/styles.ts
+++ b/src/ui/styles.ts
@@ -62,11 +62,15 @@ export const buttonConfig: PButtonConfig = {
 
 export const checkboxConfig: PCheckboxConfig = {
 	container: "inline-flex items-center",
-	label: "flex items-center cursor-pointer relative",
-	input: "peer h-4 w-4 cursor-pointer transition-all appearance-none rounded shadow hover:shadow-md border border-table-border checked:bg-blue-800 checked:border-blue-800",
+	label: "flex items-center relative ",
+	input: "peer h-4 w-4 transition-all cursor-pointer disabled:cursor-auto appearance-none rounded shadow hover:shadow-md border border-table-border",
+	colors: {
+		base: "checked:bg-blue-800 checked:border-blue-800",
+		disabled: "disabled:bg-white/10 disabled:border-white/10",
+	},
 	checkIcon:
-		"absolute text-white opacity-0 peer-checked:opacity-100 top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2",
-	checkIconSVG: "h-3.5 w-3.5",
+		"absolute opacity-0 peer-checked:opacity-100 text-white peer-disabled:text-white/20 cursor-pointer peer-disabled:cursor-auto  top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2",
+	checkIconSVG: "h-3.5 w-3.5 fill-current stroke-current stroke-1",
 };
 
 export const buttonGroupConfig: PButtonGroupConfig = {

--- a/src/ui/styles.ts
+++ b/src/ui/styles.ts
@@ -119,7 +119,7 @@ export const inputNumberConfig: PInputNumberConfig = {
 };
 
 export const inputConfig: PInputConfig = {
-	container: "rounded-sm leading-none bg-white/5 text-white/80",
+	container: "rounded-sm leading-none bg-white/5 text-white/80 overflow-hidden",
 	sizes: {
 		sm: {
 			container: "child:py-1 child:px-2",

--- a/src/ui/ui.types.ts
+++ b/src/ui/ui.types.ts
@@ -21,6 +21,7 @@ export interface PCheckboxConfig {
 	container: string;
 	label: string;
 	input: string;
+	colors: Record<"base" | "disabled", string>;
 	checkIcon: string;
 	checkIconSVG: string;
 }


### PR DESCRIPTION
I figured some smaller PR's for the less controversial stuff would be easier to review. Each change is in it's own commit here.

`PButton`: Properly enable and disable pointer state based on `disabled`.

`PCheckbox`: Similar changes, also set colors to indicate when it's disabled

`XITTransferActionButton`:  Wrap checkbox and disabled message in a div so the layout doesn't recalculate when changing the selection in the drop down (the text becoming visible was increasing the height of that grid row). Also dim the warning message to help indicate that's why the checkbox is disabled. 

`PInput`: Prevent the XIT JSON from overflowing

Before:
<img width="380" height="130" alt="image" src="https://github.com/user-attachments/assets/a282e9aa-2f43-4870-a86b-37956833ffa7" />
After:
<img width="372" height="134" alt="image" src="https://github.com/user-attachments/assets/27b6ed6a-e911-44fb-8764-8a9ee2d87925" />

