### PR TITLE
Add notice for FIO Burn tool when fio enabled

### DIFF
--- a/src/features/planning/components/tools/PlanSupplyCart.vue
+++ b/src/features/planning/components/tools/PlanSupplyCart.vue
@@ -193,9 +193,7 @@
 		supplies or focus on a specific category, and specify the duration for
 		which the supplied stock should sustain.
 		<template v-if="userStore.hasFIO">
-			<div class="text-black/80 bg-prunplanner w-100 rounded p-1 mt-1 mx-auto text-center">
-				Use the <RouterLink to="/fio/burn" class="text-blue-500 font-bold hover:underline">FIO Burn</RouterLink> tool for more advanced supply cart options
-			</div>
+			Use the <RouterLink to="/fio/burn" class="text-link-primary font-bold hover:underline">FIO Burn</RouterLink> tool for more advanced supply cart options.
 		</template>
 	</div>
 


### PR DESCRIPTION

<img width="1216" height="412" alt="image" src="https://github.com/user-attachments/assets/d5edf384-18c6-4f9d-9235-5d233c3f1f6b" />

Show an extra sentence with a router link to the `/fio/burn` if `hasFIO` is truthy. 

See https://github.com/PRUNplanner/frontend/issues/242