### PR TITLE
Update ROIOverviewTable.vue to remove Output Profit Column

### DIFF
--- a/src/features/roi_overview/components/ROIOverviewTable.vue
+++ b/src/features/roi_overview/components/ROIOverviewTable.vue
@@ -235,26 +235,6 @@
 				</template>
 			</XNDataTableColumn>
 			<XNDataTableColumn
-				key="outputProfit"
-				title="Output Profit"
-				sorter="default">
-				<template #title>
-					<div class="text-end">Output Profit</div>
-				</template>
-				<template #render-cell="{ rowData }">
-					<div
-						class="text-end text-nowrap"
-						:class="
-							rowData.outputProfit > 0
-								? 'text-positive'
-								: 'text-negative'
-						">
-						{{ formatNumber(rowData.outputProfit) }}
-						<span class="pl-1 font-light text-white/50"> $ </span>
-					</div>
-				</template>
-			</XNDataTableColumn>
-			<XNDataTableColumn
 				key="dailyProfit"
 				title="Daily Profit"
 				sorter="default">


### PR DESCRIPTION
I don't think output profit is useful on the Recipe ROI tool given the purpose of the tool is comparing apples to apples (daily profit, profit per area). Given the number of other columns, some trimming is justified, and frankly, new players may be confused by output profit. I would argue it is best removed.