### PR TITLE
Major overhaul of the PlanView layout and misc components

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
 		"vue": "^3.5.21",
 		"vue-router": "^4.5.1",
 		"vue-showdown": "^4.2.0",
+		"yalps": "^0.5.6",
 		"zod": "^4.1.5"
 	},
 	"devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -86,6 +86,9 @@ importers:
       vue-showdown:
         specifier: ^4.2.0
         version: 4.2.0(typescript@5.9.2)
+      yalps:
+        specifier: ^0.5.6
+        version: 0.5.6
       zod:
         specifier: ^4.1.5
         version: 4.1.5
@@ -1658,6 +1661,9 @@ packages:
     resolution: {integrity: sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==}
     hasBin: true
 
+  heap@0.2.7:
+    resolution: {integrity: sha512-2bsegYkkHO+h/9MGbn6KWcE45cHZgPANo5LXF7EvWdT0yT2EguSVO1nDgU5c8+ZOPwp2vMNa7YFsJhVcDR9Sdg==}
+
   highcharts-vue@2.0.1:
     resolution: {integrity: sha512-7yVaKvsWlx7OgmKFXE2D99fi/0tr2A85H4KUz3jL7CRQhAwvEvXgtDIyTBGLHJsOC5L9VlppAI7k6KfIi0j0hg==}
     peerDependencies:
@@ -2694,6 +2700,9 @@ packages:
   yallist@5.0.0:
     resolution: {integrity: sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==}
     engines: {node: '>=18'}
+
+  yalps@0.5.6:
+    resolution: {integrity: sha512-pqjmZGtEBAYuTR03G8SWVvR9vAyBBfSKup82CEJRx2Bta5j/1fRT29kwYdL2NaensQ5ugrYGLdHupNsYWPKGQg==}
 
   yargs-parser@21.1.1:
     resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
@@ -4157,6 +4166,8 @@ snapshots:
 
   he@1.2.0: {}
 
+  heap@0.2.7: {}
+
   highcharts-vue@2.0.1(highcharts@12.4.0)(vue@3.5.21(typescript@5.9.2)):
     dependencies:
       highcharts: 12.4.0
@@ -5180,6 +5191,10 @@ snapshots:
   y18n@5.0.8: {}
 
   yallist@5.0.0: {}
+
+  yalps@0.5.6:
+    dependencies:
+      heap: 0.2.7
 
   yargs-parser@21.1.1: {}
 

--- a/src/App.vue
+++ b/src/App.vue
@@ -34,7 +34,6 @@
 	);
 	const mainContentClasses = computed(() => [
 		"flex-1 flex flex-col",
-		isLoggedIn.value ? "overflow-y-auto" : "",
 	]);
 
 	onMounted(() => {

--- a/src/assets/css/style.css
+++ b/src/assets/css/style.css
@@ -7,11 +7,12 @@
 @theme {
 	--text-md: 14px;
 	--text-lg: 16px;
+	--app-bg: #030707;
 }
 
 body {
 	font-size: 14px;
-	background-color: #030707;
+	background-color: var(--app-bg);
 }
 
 html {

--- a/src/features/empire/components/EmpireCostOverview.vue
+++ b/src/features/empire/components/EmpireCostOverview.vue
@@ -16,8 +16,8 @@
 </script>
 
 <template>
-	<div class="grid grid-cols-1 2xl:grid-cols-3 gap-6 child:child:text-center">
-		<div>
+	<div class="grid grid-cols-[1fr_auto_auto_auto_1fr] gap-6 child:child:text-center">
+		<div class="col-2">
 			<div class="text-white/40 text-xs">Profit</div>
 			<div class="text-white text-xl">
 				{{ formatNumber(costOverview.totalProfit) }}

--- a/src/features/help/components/HelpDrawer.vue
+++ b/src/features/help/components/HelpDrawer.vue
@@ -62,14 +62,13 @@
 </script>
 
 <template>
-	<div :class="buttonClass">
-		<PButton
-			:size="buttonSize"
-			type="secondary"
-			@click="() => (showDrawer = !showDrawer)">
-			{{ buttonTitle }}
-		</PButton>
-	</div>
+	<PButton
+		:size="buttonSize"
+		:class="buttonClass"
+		type="secondary"
+		@click="() => (showDrawer = !showDrawer)">
+		{{ buttonTitle }}
+	</PButton>
 	<n-drawer v-model:show="showDrawer" :width="drawerWidth" placement="right">
 		<n-drawer-content closable>
 			<template #header>

--- a/src/features/planning/calculations/habOptimization.ts
+++ b/src/features/planning/calculations/habOptimization.ts
@@ -1,0 +1,94 @@
+// Linear Solver
+import { solve, lessEq, greaterEq, Model, Constraint, Solution } from "yalps";
+
+// Types & Interfaces
+import {
+	INFRASTRUCTURE_TYPE,
+	IWorkforceRecord,
+} from "@/features/planning/usePlanCalculation.types";
+import { IInfrastructureCosts } from "@/features/cx/usePrice.types";
+
+const HabArea = {
+	HB1: 10,
+	HB2: 12,
+	HB3: 14,
+	HB4: 16,
+	HB5: 18,
+	HBB: 14,
+	HBC: 17,
+	HBM: 20,
+	HBL: 22,
+};
+
+export function calculateAvailableArea(
+totalArea: number, usedArea: number, infrastructure: Record<INFRASTRUCTURE_TYPE, number>): number {
+	let currentHabArea = 0;
+	for (let habType in HabArea) {
+		const habCount = infrastructure[habType as INFRASTRUCTURE_TYPE] || 0;
+		const habArea = HabArea[habType as keyof typeof HabArea];
+		currentHabArea += habCount * habArea;
+	}
+	const productionArea = usedArea - currentHabArea;
+	return totalArea - productionArea;
+}
+
+export type HabSolverGoal = "auto" | "cost" | "area";
+export function optimizeHabs(
+	goal: HabSolverGoal,
+	costs: IInfrastructureCosts,
+	workforceRequired: IWorkforceRecord,
+	availableArea: number,
+	constrainArea: boolean = false
+): Solution {
+	if (goal === "auto") {
+		const costWorked = optimizeHabs(
+			"cost",
+			costs,
+			workforceRequired,
+			availableArea,
+			constrainArea=true
+		);
+		if (costWorked.status === "optimal") {
+			return costWorked;
+		}
+		// We couldn't fit into the area, try again minimizing area (which isn't bounded)
+		return optimizeHabs("area", costs, workforceRequired, availableArea);
+	}
+
+	let constraints = new Map<string, Constraint>();
+	for (let workforceType in workforceRequired) {
+		const required =
+			workforceRequired[workforceType as keyof IWorkforceRecord].required;
+		if (required !== 0) {
+			constraints.set(workforceType, greaterEq(required));
+		}
+	}
+	// prettier-ignore
+	const variables = {
+		HB1: { area: HabArea.HB1, cost: costs.HB1, pioneer: 100, settler: 0,   technician: 0,   engineer: 0,   scientist: 0   },
+		HB2: { area: HabArea.HB2, cost: costs.HB2, pioneer: 0,   settler: 100, technician: 0,   engineer: 0,   scientist: 0   },
+		HB3: { area: HabArea.HB3, cost: costs.HB3, pioneer: 0,   settler: 0,   technician: 100, engineer: 0,   scientist: 0   },
+		HB4: { area: HabArea.HB4, cost: costs.HB4, pioneer: 0,   settler: 0,   technician: 0,   engineer: 100, scientist: 0   },
+		HB5: { area: HabArea.HB5, cost: costs.HB5, pioneer: 0,   settler: 0,   technician: 0,   engineer: 0,   scientist: 100 },
+		HBB: { area: HabArea.HBB, cost: costs.HBB, pioneer: 75,  settler: 75,  technician: 0,   engineer: 0,   scientist: 0   },
+		HBC: { area: HabArea.HBC, cost: costs.HBC, pioneer: 0,   settler: 75,  technician: 75,  engineer: 0,   scientist: 0   },
+		HBM: { area: HabArea.HBM, cost: costs.HBM, pioneer: 0,   settler: 0,   technician: 75,  engineer: 75,  scientist: 0   },
+		HBL: { area: HabArea.HBL, cost: costs.HBL, pioneer: 0,   settler: 0,   technician: 0,   engineer: 75,  scientist: 75  },
+	};
+
+	if (goal === "cost" && constrainArea) {
+		constraints.set("area", lessEq(availableArea));
+	}
+	// If goal is area, we do not set an area constraint so we'll find a result even if we don't fit
+
+	const model: Model = {
+		direction: "minimize",
+		objective: goal,
+		constraints: constraints,
+		variables: variables,
+		// prettier-ignore
+		integers: ["HB1", "HB2", "HB3", "HB4", "HB5", "HBB", "HBC", "HBM", "HBL"],
+	};
+
+	return solve(model, { includeZeroVariables: true });
+}

--- a/src/features/planning/components/PlanExperts.vue
+++ b/src/features/planning/components/PlanExperts.vue
@@ -56,7 +56,7 @@
 		{{ totalExperts }} experts assigned.
 	</div>
 	<div
-		class="grid grid-cols-1 xl:grid-cols-[auto_auto_auto] gap-x-1 gap-y-3 child:my-auto">
+		class="grid grid-cols-[repeat(3,auto)] sm:grid-cols-[repeat(6,auto)] gap-3 child:my-auto">
 		<template v-for="expert in expertData" :key="expert.name">
 			<div>{{ capitalizeString(expert.name) }}</div>
 			<PInputNumber
@@ -65,7 +65,7 @@
 				show-buttons
 				:min="0"
 				:max="5"
-				class="w-full min-w-[70px]"
+				class="min-w-[80px] max-w-[100px]"
 				@update:value="
 					(value) => {
 						if (value !== null && value !== undefined) {

--- a/src/features/planning/components/PlanInfrastructure.vue
+++ b/src/features/planning/components/PlanInfrastructure.vue
@@ -1,5 +1,10 @@
 <script setup lang="ts">
-	import { computed, ComputedRef, PropType } from "vue";
+	import {
+		computed,
+		ComputedRef,
+		PropType,
+		WritableComputedRef,
+	} from "vue";
 	import { trackEvent } from "@/lib/analytics/useAnalytics";
 
 	// Types & Interfaces
@@ -9,10 +14,15 @@
 	} from "@/features/planning/usePlanCalculation.types";
 
 	// UI
-	import { PInputNumber } from "@/ui";
+	import { PButton, PForm, PFormItem, PCheckbox, PInputNumber, PTooltip } from "@/ui";
+import { HabSolverGoal } from "../calculations/habOptimization";
 
 	const props = defineProps({
 		disabled: {
+			type: Boolean,
+			required: true,
+		},
+		autoOptimizeHabs: {
 			type: Boolean,
 			required: true,
 		},
@@ -32,6 +42,8 @@
 			infrastructure: INFRASTRUCTURE_TYPE,
 			value: number
 		): void;
+		(e: "update:auto-optimize-habs", value: boolean): void;
+		(e: "optimize-habs", goal: HabSolverGoal): void;
 	}>();
 
 	// Local State
@@ -50,19 +62,40 @@
 		"HB5",
 		"STO",
 	];
+
+	const localAutoOptimizeHabs: WritableComputedRef<boolean> = computed({
+		get: () => props.autoOptimizeHabs,
+		set: (value: boolean) => {
+			emit("update:auto-optimize-habs", value);
+		},
+	});
 </script>
 
 <template>
-	<div
-		class="grid grid-cols-1 lg:grid-cols-[auto_auto_auto_auto] gap-3 child:my-auto">
+	<div class="mb-3">
+		<PForm>
+			<PFormItem label="Auto-Optimize Habs">
+				<PTooltip>
+					<template #trigger>
+						<PCheckbox
+							v-model:checked="localAutoOptimizeHabs"
+							:disabled="disabled" />
+					</template>
+					Automatically optimize habitations to meet<br />workforce
+					needs as buildings are added.
+				</PTooltip>
+			</PFormItem>
+		</PForm>
+	</div>
+	<div class="grid grid-cols-[repeat(4,auto)] gap-3 child:my-auto">
 		<template v-for="inf in infrastructureOrder" :key="inf">
 			<div>{{ inf }}</div>
 			<PInputNumber
 				v-model:value="localInfrastructureData[inf]"
-				:disabled="disabled"
+				:disabled="disabled || (localAutoOptimizeHabs && inf !== 'STO')"
 				show-buttons
 				:min="0"
-				class="w-full min-w-[80px]"
+				class="min-w-[85px] max-w-[100px]"
 				@update:value="
 					(value) => {
 						if (value !== null && value !== undefined) {
@@ -76,5 +109,19 @@
 					}
 				" />
 		</template>
+		<div class="col-span-2 justify-self-center">
+			<PButton
+				:disabled="disabled || localAutoOptimizeHabs"
+				@click="emit('optimize-habs', 'cost')">
+				Optimize Cost
+			</PButton>
+		</div>
+		<div class="col-span-2 justify-self-center">
+			<PButton
+				:disabled="disabled || localAutoOptimizeHabs"
+				@click="emit('optimize-habs', 'area')">
+				Optimize Area
+			</PButton>
+		</div>
 	</div>
 </template>

--- a/src/features/planning/components/PlanOverview.vue
+++ b/src/features/planning/components/PlanOverview.vue
@@ -26,60 +26,114 @@
 </script>
 
 <template>
-	<PTable striped>
-		<tbody class="child:child:first:font-bold child:child:last:text-end">
-			<tr>
-				<td>Storage</td>
-				<td>
-					{{ formatNumber(visitationData.storageFilled) }}
-					<span class="font-light text-white/50"> d </span>
-				</td>
-			</tr>
-			<tr>
-				<td>Daily Cost</td>
-				<td>
-					{{ formatNumber(overviewData.dailyCost) }}
-					<span class="font-light text-white/50"> $ </span>
-				</td>
-			</tr>
-			<tr>
-				<td>Degradation</td>
-				<td>
-					{{ formatNumber(overviewData.dailyDegradationCost) }}
-					<span class="font-light text-white/50"> $ </span>
-				</td>
-			</tr>
-			<tr>
-				<td>Daily Profit</td>
-				<td
-					:class="
-						overviewData.profit >= 0
-							? '!text-positive'
-							: '!text-negative'
-					">
-					{{ formatNumber(overviewData.profit) }}
-					<span class="font-light text-white/50"> $ </span>
-				</td>
-			</tr>
-			<tr>
-				<td>Plan Cost</td>
-				<td>
-					{{ formatNumber(overviewData.totalConstructionCost) }}
-					<span class="font-light text-white/50"> $ </span>
-				</td>
-			</tr>
-			<tr>
-				<td>ROI</td>
-				<td
-					:class="
-						overviewData.roi > 0
-							? '!text-positive'
-							: '!text-negative'
-					">
-					{{ formatNumber(overviewData.roi) }}
-					<span class="font-light text-white/50"> d </span>
-				</td>
-			</tr>
-		</tbody>
-	</PTable>
+	<div class="flex flex-row gap-6 child:shrink-0">
+		<div>
+			<slot name="heading" text="Overview"></slot>
+			<PTable striped>
+				<tbody
+					class="child:child:first:font-bold child:child:last:text-end">
+					<tr>
+						<td>Storage</td>
+						<td>
+							{{ formatNumber(visitationData.storageFilled) }}
+							<span class="font-light text-white/50"> d </span>
+						</td>
+					</tr>
+					<tr>
+						<td>Daily Cost</td>
+						<td>
+							{{ formatNumber(overviewData.dailyCost) }}
+							<span class="font-light text-white/50"> $ </span>
+						</td>
+					</tr>
+					<tr>
+						<td>Degradation</td>
+						<td>
+							{{
+								formatNumber(overviewData.dailyDegradationCost)
+							}}
+							<span class="font-light text-white/50"> $ </span>
+						</td>
+					</tr>
+					<tr>
+						<td>Daily Profit</td>
+						<td
+							:class="
+								overviewData.profit >= 0
+									? '!text-positive'
+									: '!text-negative'
+							">
+							{{ formatNumber(overviewData.profit) }}
+							<span class="font-light text-white/50"> $ </span>
+						</td>
+					</tr>
+					<tr>
+						<td>Plan Cost</td>
+						<td>
+							{{
+								formatNumber(overviewData.totalConstructionCost)
+							}}
+							<span class="font-light text-white/50"> $ </span>
+						</td>
+					</tr>
+					<tr>
+						<td>ROI</td>
+						<td
+							:class="
+								overviewData.roi > 0
+									? '!text-positive'
+									: '!text-negative'
+							">
+							{{ formatNumber(overviewData.roi) }}
+							<span class="font-light text-white/50"> d </span>
+						</td>
+					</tr>
+				</tbody>
+			</PTable>
+		</div>
+		<div>
+			<slot name="heading" text="Storage"></slot>
+			<PTable striped>
+				<thead class="child:text-center">
+					<tr>
+						<th />
+						<th>m³</th>
+						<th>t</th>
+					</tr>
+				</thead>
+				<tbody class="child:child:text-center">
+					<tr>
+						<td class="!text-left font-bold">Import</td>
+						<td>
+							{{ formatNumber(visitationData.dailyVolumeImport) }}
+						</td>
+						<td>
+							{{ formatNumber(visitationData.dailyWeightImport) }}
+						</td>
+					</tr>
+					<tr>
+						<td class="!text-left font-bold">Export</td>
+						<td>
+							{{ formatNumber(visitationData.dailyVolumeExport) }}
+						</td>
+						<td>
+							{{ formatNumber(visitationData.dailyWeightExport) }}
+						</td>
+					</tr>
+					<tr>
+						<td class="!text-left font-bold">&#8721;</td>
+						<td>{{ formatNumber(visitationData.dailyVolume) }}</td>
+						<td>{{ formatNumber(visitationData.dailyWeight) }}</td>
+					</tr>
+					<tr>
+						<td class="!text-left font-bold">Filled</td>
+						<td colspan="2" class="font-bold">
+							{{ formatNumber(visitationData.storageFilled) }}
+							days
+						</td>
+					</tr>
+				</tbody>
+			</PTable>
+		</div>
+	</div>
 </template>

--- a/src/features/planning/components/PlanProduction.vue
+++ b/src/features/planning/components/PlanProduction.vue
@@ -6,14 +6,19 @@
 	import { trackEvent } from "@/lib/analytics/useAnalytics";
 
 	// Components
+	import MaterialTile from "@/features/material_tile/components/MaterialTile.vue";
 	import PlanProductionBuilding from "@/features/planning/components/PlanProductionBuilding.vue";
 
 	// Types & Interfaces
+	import { IPlanetResource } from "@/features/api/gameData.types";
 	import { IProductionResult } from "@/features/planning/usePlanCalculation.types";
 	import { PLAN_COGCPROGRAM_TYPE } from "@/stores/planningStore.types";
 
 	// UI
-	import { PCheckbox, PSelect } from "@/ui";
+	import { PCheckbox, PSelect, PTooltip } from "@/ui";
+
+	// Util
+	import { formatNumber } from "@/util/numbers";
 
 	const props = defineProps({
 		disabled: {
@@ -35,6 +40,10 @@
 		},
 		planetId: {
 			type: String,
+			required: true,
+		},
+		planetResources: {
+			type: Object as PropType<IPlanetResource[]>,
 			required: true,
 		},
 	});
@@ -78,18 +87,52 @@
 </script>
 
 <template>
-	<div class="flex flex-row gap-x-3 pb-3 justify-between child:my-auto">
-		<h2 class="text-white/80 font-bold text-lg">Production</h2>
-
-		<div class="flex child:my-auto gap-x-3">
-			<div class="text-sm">Match COGC</div>
-			<PCheckbox v-model:checked="localMatchCOGC" :disabled="disabled" />
+	<h2 class="text-white/80 font-bold text-lg">Production</h2>
+	<div
+		class="grid grid-cols-1 sm:grid-cols-[auto_1fr] gap-3 py-3 child:my-auto">
+		<div class="flex gap-3 child:my-auto">
+			<div class="text-sm">Planet Resources</div>
+			<div class="flex flex-wrap gap-1 child:my-auto">
+				<PTooltip
+					v-for="resource in planetResources"
+					:key="`PLANET#RESOURCE#${resource.MaterialTicker}`">
+					<template #trigger>
+						<div class="hover:cursor-help">
+							<MaterialTile
+								:key="resource.MaterialTicker"
+								:ticker="resource.MaterialTicker"
+								:amount="
+									parseFloat(
+										formatNumber(resource.DailyExtraction)
+									)
+								"
+								disable-drawer
+								:enable-popover="false" />
+						</div>
+					</template>
+					{{ resource.ResourceType }} ({{
+						resource.ResourceType === "MINERAL"
+							? "EXT"
+							: resource.ResourceType === "GASEOUS"
+							? "COL"
+							: "RIG"
+					}})
+				</PTooltip>
+			</div>
+		</div>
+		<div class="sm:justify-self-end-safe flex child:my-auto gap-3">
+			<div class="flex gap-3">
+				<div class="text-sm text-nowrap">Match COGC</div>
+				<PCheckbox
+					v-model:checked="localMatchCOGC"
+					:disabled="disabled" />
+			</div>
 
 			<PSelect
 				v-model:value="localSelectedBuilding"
 				:disabled="disabled"
 				searchable
-				class="w-full lg:!w-[300px]"
+				class="w-full sm:!w-[300px]"
 				:options="
 					getProductionBuildingOptions(
 						localProductionData.buildings.map((e) => e.name),

--- a/src/features/planning/components/PlanProductionBuilding.vue
+++ b/src/features/planning/components/PlanProductionBuilding.vue
@@ -65,16 +65,40 @@
 	const localBuildingData: ComputedRef<IProductionBuilding> = computed(
 		() => props.buildingData
 	);
+
+	const expertiseString = computed(() => {
+		if (localBuildingData.value.expertise) {
+			return localBuildingData.value.expertise
+				.replaceAll("_", " ")
+				.toLowerCase();
+		}
+		return "";
+	});
+
+	const isPlanetCogc = computed(() => {
+		return localBuildingData.value.efficiencyElements.some(
+			(element) => element.efficiencyType === "COGC"
+		);
+	});
 </script>
 
 <template>
 	<div class="mb-6">
 		<div
-			class="p-3 rounded-tl rounded-tr border-pp-border border-l border-t border-r flex gap-x-3 justify-between">
-			<h3 class="text-2xl font-bold text-white">
-				{{ localBuildingData.name }}
-			</h3>
-			<div class="flex flex-row flex-wrap gap-x-1">
+			class="p-3 rounded-tl rounded-tr border-pp-border border-l border-t border-r grid gap-3 grid-cols-1 grid-rows-[auto_auto] @lg:grid-cols-[1fr_1fr] @lg:grid-rows-1">
+			<div class="flex flex-row gap-x-3 items-baseline">
+				<h3 class="text-2xl font-bold text-white">
+					{{ localBuildingData.name }} -
+					{{ localBuildingData.amount }}
+				</h3>
+				<span
+					class="capitalize"
+					:class="isPlanetCogc ? 'text-positive' : ''"
+					>{{ expertiseString }}</span
+				>
+			</div>
+			<div
+				class="col-1 row-2 @lg:row-1 @lg:col-2 @lg:justify-self-end-safe flex flex-row flex-wrap gap-x-1">
 				<PInputNumber
 					v-model:value="localBuildingData.amount"
 					:disabled="disabled"
@@ -156,42 +180,54 @@
 			</div>
 		</div>
 		<div
-			class="p-3 border-pp-border border rounded-bl rounded-br bg-white/5 flex flex-row gap-x-3 justify-between">
-			<div>
-				<PTooltip>
-					<template #trigger>
-						<div class="flex gap-x-3 hover:cursor-help">
-							<span>Efficiency</span>
-							<span class="font-bold">
-								{{
-									formatNumber(
-										localBuildingData.totalEfficiency * 100
-									)
-								}}
-								%
-							</span>
-						</div>
-					</template>
-
-					<div
-						v-for="element in localBuildingData.efficiencyElements"
-						:key="`${localBuildingData.name}#EFFICIENCY#${element.efficiencyType}`"
-						class="flex flex-row justify-between align-center gap-x-3 child:p-1">
-						<div>{{ element.efficiencyType }}</div>
-						<div>{{ formatNumber(element.value * 100) }} %</div>
+			class="p-3 border-pp-border border rounded-bl rounded-br bg-white/5 text-nowrap flex flex-row flex-wrap gap-x-3 justify-between">
+			<PTooltip>
+				<template #trigger>
+					<div class="flex gap-x-3 hover:cursor-help">
+						<span>Efficiency</span>
+						<span class="font-bold">
+							{{
+								formatNumber(
+									localBuildingData.totalEfficiency * 100
+								)
+							}}
+							%
+						</span>
 					</div>
-				</PTooltip>
-			</div>
-			<div class="flex gap-x-3">
-				<span>Revenue</span>
-				<span class="font-bold">
-					{{ formatNumber(localBuildingData.dailyRevenue) }} $
-				</span>
-				<span>Construction Cost</span>
-				<span class="font-bold">
-					{{ formatNumber(localBuildingData.constructionCost * -1) }}
-					$
-				</span>
+				</template>
+
+				<div
+					v-for="element in localBuildingData.efficiencyElements"
+					:key="`${localBuildingData.name}#EFFICIENCY#${element.efficiencyType}`"
+					class="flex flex-row justify-between align-center gap-x-3 child:p-1">
+					<div>{{ element.efficiencyType }}</div>
+					<div>{{ formatNumber(element.value * 100) }} %</div>
+				</div>
+			</PTooltip>
+			<div class="flex flex-wrap gap-x-3">
+				<div class="flex gap-x-3">
+					<span>Revenue</span>
+					<span
+						class="font-bold"
+						:class="
+							localBuildingData.dailyRevenue >= 0
+								? '!text-positive'
+								: '!text-negative'
+						">
+						{{ formatNumber(localBuildingData.dailyRevenue) }} $
+					</span>
+				</div>
+				<div class="flex gap-x-3">
+					<span>Construction Cost</span>
+					<span class="font-bold">
+						{{
+							formatNumber(
+								localBuildingData.constructionCost * -1
+							)
+						}}
+						$
+					</span>
+				</div>
 			</div>
 		</div>
 	</div>

--- a/src/features/planning/components/PlanStatusBar.vue
+++ b/src/features/planning/components/PlanStatusBar.vue
@@ -1,0 +1,114 @@
+<script setup lang="ts">
+	import { computed, PropType } from "vue";
+	import { trackEvent } from "@/lib/analytics/useAnalytics";
+
+	// Types & Interfaces
+	import {
+		IAreaResult,
+		IExpertRecord,
+		IOverviewData,
+	} from "@/features/planning/usePlanCalculation.types";
+	import { PLAN_COGCPROGRAM_TYPE } from "@/stores/planningStore.types";
+
+	// Util
+	import { formatNumber } from "@/util/numbers";
+
+	// UI
+	import {} from "@/ui";
+
+	const props = defineProps({
+		areaData: {
+			type: Object as PropType<IAreaResult>,
+			required: true,
+		},
+		corphq: {
+			type: Boolean,
+			required: true,
+		},
+		cogc: {
+			type: String as PropType<PLAN_COGCPROGRAM_TYPE>,
+			required: true,
+		},
+		expertData: {
+			type: Object as PropType<IExpertRecord>,
+			required: true,
+		},
+		overviewData: {
+			type: Object as PropType<IOverviewData>,
+			required: true,
+		},
+	});
+
+	const cogcTextMapping: Record<PLAN_COGCPROGRAM_TYPE, string> = {
+		"---": "None",
+		AGRICULTURE: "Agriculture",
+		CHEMISTRY: "Chemistry",
+		CONSTRUCTION: "Construction",
+		ELECTRONICS: "Electronics",
+		FOOD_INDUSTRIES: "Food Industries",
+		FUEL_REFINING: "Fuel Refining",
+		MANUFACTURING: "Manufacturing",
+		METALLURGY: "Metallurgy",
+		RESOURCE_EXTRACTION: "Resource Extraction",
+		PIONEERS: "Pioneers",
+		SETTLERS: "Settlers",
+		TECHNICIANS: "Technicians",
+		ENGINEERS: "Engineers",
+		SCIENTISTS: "Scientists",
+	};
+
+	const expertsString = computed(() => {
+		let experts = "";
+
+		for (const expertKey in props.expertData) {
+			const expert = props.expertData[expertKey as keyof IExpertRecord];
+			if (expert.amount > 0) {
+				if (experts.length > 0) experts += ", ";
+				experts += `${expert.amount}x${expert.name.substring(0, 4)}`;
+			}
+		}
+		if (experts.length === 0) experts = "None";
+		return experts;
+	});
+</script>
+
+<template>
+	<div class="flex flex-row font-bold child:mr-3">
+		<div :class="corphq ? 'visible' : 'collapse md:invisible'">
+			<span class="text-positive">HQ</span>
+		</div>
+		<div>
+			<span>COGC: </span>
+			<span :class="props.cogc === '---' ? 'text-negative' : ''">{{
+				cogcTextMapping[props.cogc]
+			}}</span>
+		</div>
+		<div>
+			<span>Area: </span>
+			<span
+				:class="
+					areaData.areaUsed > areaData.areaTotal
+						? 'text-negative'
+						: ''
+				"
+				>{{ areaData.areaUsed }}
+			</span>
+			<span>/{{ areaData.areaTotal }}</span>
+		</div>
+		<div>
+			<span>Profit: </span>
+			<span
+				:class="
+					overviewData.profit > 0 ? 'text-positive' : 'text-negative'
+				"
+				>{{ formatNumber(overviewData.profit) }}</span
+			>
+		</div>
+		<div>
+			<span>Experts: </span>
+			<span :class="expertsString === 'None' ? 'text-negative' : ''">{{
+				expertsString
+			}}</span>
+		</div>
+	</div>
+</template>

--- a/src/features/planning/usePlanCalculation.ts
+++ b/src/features/planning/usePlanCalculation.ts
@@ -587,6 +587,7 @@ export async function usePlanCalculation(
 				workforceMaterials: workforceMaterials,
 				workforceDailyCost: workforceDailyCost,
 				dailyRevenue: 0,
+				expertise: buildingData.Expertise,
 			};
 
 			// Calculating individual buildings daily contribution

--- a/src/features/planning/usePlanCalculation.types.ts
+++ b/src/features/planning/usePlanCalculation.types.ts
@@ -1,4 +1,4 @@
-import { IBuilding, IRecipe } from "@/features/api/gameData.types";
+import { BUILDING_EXPERTISE_TYPE, IBuilding, IRecipe } from "@/features/api/gameData.types";
 import { IBuildingEfficiency } from "@/features/planning/calculations/bonusCalculations.types";
 import { PLAN_COGCPROGRAM_TYPE } from "@/stores/planningStore.types";
 import { IInfrastructureCosts } from "../cx/usePrice.types";
@@ -124,6 +124,7 @@ export interface IProductionBuilding {
 	workforceMaterials: IMaterialIOMinimal[];
 	workforceDailyCost: number;
 	dailyRevenue: number;
+	expertise: BUILDING_EXPERTISE_TYPE | null;
 }
 
 export interface IProductionResult {

--- a/src/features/planning/usePlanCalculationHandlers.ts
+++ b/src/features/planning/usePlanCalculationHandlers.ts
@@ -392,6 +392,17 @@ export async function usePlanCalculationHandlers(
 		modified.value = true;
 	}
 
+	/**
+	 * Updates the Auto Optimize Habitations Setting
+	 * @author jplacht
+	 *
+	 * @param {boolean} value Plan should automatically optimize habitations
+	 */
+	function handleUpdateAutoOptimizeHabs(value: boolean): void {
+		// Stub, back-end can't store this yet
+		modified.value = true;
+	}
+
 	return {
 		modified,
 		// handlers
@@ -410,5 +421,6 @@ export async function usePlanCalculationHandlers(
 		handleAddBuildingRecipe,
 		handleChangeBuildingRecipe,
 		handleChangePlanName,
+		handleUpdateAutoOptimizeHabs,
 	};
 }

--- a/src/layout/components/NavigationBar.vue
+++ b/src/layout/components/NavigationBar.vue
@@ -311,8 +311,9 @@
 	<input id="menu-toggle" type="checkbox" class="hidden peer" />
 	<!-- Sidebar -->
 	<div
-		class="hidden peer-checked:flex md:flex border-r border-white/5 flex-col bg-gray-dark transition-all duration-300 ease-in-out"
-		:class="containerClass">
+		class="hidden peer-checked:flex md:h-screen md:sticky md:top-0 md:flex border-r border-white/5 flex-col bg-gray-dark transition-all duration-300 ease-in-out"
+		:class="containerClass"
+		style="scrollbar-width: none">
 		<div class="items-center justify-between sm:hidden md:flex">
 			<div class="w-full flex flex-row items-baseline pt-4">
 				<div

--- a/src/views/EmpireView.vue
+++ b/src/views/EmpireView.vue
@@ -307,7 +307,7 @@
 					message="One does not simply calculate empire plans." />
 
 				<div v-else>
-					<div class="min-h-screen flex flex-col">
+					<div class="flex flex-col">
 						<div
 							class="px-6 py-3 border-b border-white/10 flex flex-row justify-between gap-x-3">
 							<div class="flex flex-row gap-3">
@@ -325,10 +325,10 @@
 						</div>
 
 						<div
-							class="flex-grow grid grid-cols-1 lg:grid-cols-[40%_auto] divide-x divide-white/10">
+							class="flex-grow grid grid-cols-1 xl:grid-cols-[1fr_auto]">
 							<div>
 								<div
-									class="px-6 pb-3 pt-4 border-b border-white/10 my-auto">
+									class="px-6 pb-3 pt-6 my-auto">
 									<PForm>
 										<PFormItem label="Switch Empire">
 											<PSelect
@@ -348,31 +348,39 @@
 										</PFormItem>
 									</PForm>
 								</div>
-								<div class="p-6 border-b border-white/10">
+								<div class="p-6">
 									<AsyncEmpireCostOverview
 										:cost-overview="costOverview" />
 								</div>
-								<div class="p-6 border-b border-white/10">
-									<Suspense>
-										<AsyncEmpirePlanList
-											:plan-list-data="planListData" />
-										<template #fallback>
-											<RenderingProgress :height="200" />
-										</template>
-									</Suspense>
-								</div>
-								<div class="p-6 border-b border-white/10">
-									<Suspense v-if="selectedEmpire">
-										<AsyncEmpireConfiguration
-											:data="selectedEmpire"
-											@reload:empires="reloadEmpires" />
-										<template #fallback>
-											<RenderingProgress :height="200" />
-										</template>
-									</Suspense>
+								<div class="flex flex-wrap child:p-6">
+									<div>
+										<Suspense>
+											<AsyncEmpirePlanList
+												:plan-list-data="
+													planListData
+												" />
+											<template #fallback>
+												<RenderingProgress
+													:height="200" />
+											</template>
+										</Suspense>
+									</div>
+									<div>
+										<Suspense v-if="selectedEmpire">
+											<AsyncEmpireConfiguration
+												:data="selectedEmpire"
+												@reload:empires="
+													reloadEmpires
+												" />
+											<template #fallback>
+												<RenderingProgress
+													:height="200" />
+											</template>
+										</Suspense>
+									</div>
 								</div>
 							</div>
-							<div class="p-6">
+							<div class="p-6 overflow-x-auto">
 								<EmpireMaterialIOFiltered
 									:content="mainContent"
 									:empire-material-i-o="


### PR DESCRIPTION
PlanView:
- Removed Configuration sidebar
- Replaced with new Configuration "tool"
- Added sticky "Status Bar" that displays the import Plan configs & profit
- Added most of an auto-optimize habs option
  - New dependency YALPS (linear solver): https://github.com/Ivordir/YALPS
  - Needs server side changes to persist the new boolean on the plan (currently forced on)
  - Removed old Habiation Optimization tool
  - Added an Optimzie Cost/Area button to PlanInfrastructure
- Made the design much more responsive, 2 major breakpoints based off a viewport

PlanProductionBuilding:
- Added building COGC to IProductionBuilding so it could be displayed

App:
- Removed overflow-y-auto from main content container, this was prevented using sticky

EmpireView:
- Adjusted an made more responsive after removing the app level overflow-y-auto

EmpireCostOverview:
- Adjusted to be more responsive

NavigationBar:
- Made sticky and sized to viewport, prevents the bottom FIO indicator and collapse arrow from going off screen

HelpDrawer:
- Removed extra div so PButtonGroup would style it correctly