### PR TITLE
Plan view tweaks from feedback

### DIFF
--- a/src/features/planning/components/PlanOverview.vue
+++ b/src/features/planning/components/PlanOverview.vue
@@ -43,6 +43,8 @@
 			<PTable striped>
 				<tbody
 					class="child:child:first:font-bold child:child:last:text-end">
+					<!-- empty row to make the background colors match the other tables-->
+					<tr />
 					<tr>
 						<td>Daily Cost</td>
 						<td>

--- a/src/features/planning/components/PlanProductionBuilding.vue
+++ b/src/features/planning/components/PlanProductionBuilding.vue
@@ -180,32 +180,40 @@
 		</div>
 		<div
 			class="p-3 border-pp-border border rounded-bl rounded-br bg-white/5 text-nowrap flex flex-row flex-wrap gap-x-3 justify-between">
-			<PTooltip>
-				<template #trigger>
-					<div class="flex gap-x-3 hover:cursor-help">
-						<span>Efficiency</span>
-						<span class="font-bold">
-							{{
-								formatNumber(
-									localBuildingData.totalEfficiency * 100
-								)
-							}}
-							%
-						</span>
-					</div>
-				</template>
-
-				<div
-					v-for="element in localBuildingData.efficiencyElements"
-					:key="`${localBuildingData.name}#EFFICIENCY#${element.efficiencyType}`"
-					class="flex flex-row justify-between align-center gap-x-3 child:p-1">
-					<div>{{ element.efficiencyType }}</div>
-					<div>{{ formatNumber(element.value * 100) }} %</div>
-				</div>
-			</PTooltip>
 			<div class="flex flex-wrap gap-x-3">
-				<div class="flex gap-x-3">
-					<span>Revenue</span>
+				<PTooltip>
+					<template #trigger>
+						<div class="flex gap-x-1 hover:cursor-help">
+							<span>Efficiency:</span>
+							<span class="font-bold">
+								{{
+									formatNumber(
+										localBuildingData.totalEfficiency * 100
+									)
+								}}
+								%
+							</span>
+						</div>
+					</template>
+
+					<div
+						v-for="element in localBuildingData.efficiencyElements"
+						:key="`${localBuildingData.name}#EFFICIENCY#${element.efficiencyType}`"
+						class="flex flex-row justify-between align-center gap-x-3 child:p-1">
+						<div>{{ element.efficiencyType }}</div>
+						<div>{{ formatNumber(element.value * 100) }} %</div>
+					</div>
+				</PTooltip>
+				<div class="flex gap-x-1">
+					<span>Area:</span>
+					<span class="font-bold">
+						{{ localBuildingData.areaUsed }}
+					</span>
+				</div>
+			</div>
+			<div class="flex flex-wrap gap-x-3">
+				<div class="flex gap-x-1">
+					<span>Revenue:</span>
 					<span
 						class="font-bold"
 						:class="
@@ -216,8 +224,8 @@
 						{{ formatNumber(localBuildingData.dailyRevenue) }} $
 					</span>
 				</div>
-				<div class="flex gap-x-3">
-					<span>Construction Cost</span>
+				<div class="flex gap-x-1">
+					<span>Construction Cost:</span>
 					<span class="font-bold">
 						{{
 							formatNumber(

--- a/src/features/planning/usePlanCalculation.ts
+++ b/src/features/planning/usePlanCalculation.ts
@@ -476,7 +476,7 @@ export async function usePlanCalculation(
 					const optimalProductionData = optimalProduction.find((op) => op.ticker === br.BuildingTicker);
 					const areaPerBuilding: number = optimalProductionData ? optimalProductionData.total_area / optimalProductionData.amount : buildingData.AreaCost;
 
-					const profitPerArea = dailyRevenue / areaPerBuilding; 
+					const profitPerArea = dailyRevenue / areaPerBuilding;
 
 					return {
 						RecipeId: br.RecipeId,
@@ -587,6 +587,7 @@ export async function usePlanCalculation(
 			const building: IProductionBuilding = {
 				name: b.name,
 				amount: b.amount,
+				areaUsed: buildingData.AreaCost * b.amount,
 				activeRecipes: activeRecipes,
 				recipeOptions: recipeOptions,
 				totalEfficiency: totalEfficiency,

--- a/src/features/planning/usePlanCalculation.types.ts
+++ b/src/features/planning/usePlanCalculation.types.ts
@@ -115,6 +115,7 @@ export interface IProductionBuildingRecipe {
 export interface IProductionBuilding {
 	name: string;
 	amount: number;
+	areaUsed: number;
 	activeRecipes: IProductionBuildingRecipe[];
 	recipeOptions: IRecipeBuildingOption[];
 	totalEfficiency: number;

--- a/src/ui/styles.ts
+++ b/src/ui/styles.ts
@@ -75,9 +75,9 @@ export const checkboxConfig: PCheckboxConfig = {
 
 export const buttonGroupConfig: PButtonGroupConfig = {
 	horizontal:
-		"inline-flex child:rounded-none [&_button]:first:!rounded-l-sm [&_button]:last:!rounded-r-sm",
+		"inline-flex child:rounded-none [&_button]:first:rounded-l-sm [&_button]:last:rounded-r-sm",
 	vertical:
-		"inline-flex flex-col child:rounded-none [&_button]:first:!rounded-t-sm [&_button]:last:!rounded-b-sm",
+		"inline-flex flex-col child:rounded-none [&_button]:first:rounded-t-sm [&_button]:last:rounded-b-sm",
 };
 
 export const tooltipConfig: PTooltipConfig = {

--- a/src/views/PlanView.vue
+++ b/src/views/PlanView.vue
@@ -73,6 +73,7 @@
 		SaveSharp,
 		ChangeCircleOutlined,
 		ContentCopySharp,
+		SettingsSharp,
 	} from "@vicons/material";
 	import { onBeforeRouteLeave } from "vue-router";
 
@@ -530,17 +531,26 @@
 						<span v-if="!sharedWasCloned"> Clone Plan </span>
 						<span v-else> Cloning Complete </span>
 					</PButton>
-					<PButton
-						v-if="saveable"
-						:loading="refIsSaving"
-						:type="modified ? 'error' : 'success'"
-						:disabled="disabled"
-						@click="save">
-						<template #icon>
-							<SaveSharp />
+					<PTooltip :disabled="saveable">
+						<template #trigger>
+							<!-- ButtonGroup styling doesn't work quite right with this
+							 being wrapped in a tooltip, explicitly set rounded on it -->
+							<PButton
+								:loading="refIsSaving"
+								:type="
+									modified || !saveable ? 'error' : 'success'
+								"
+								:disabled="disabled || !saveable"
+								class="!rounded-none !rounded-l-sm"
+								@click="save">
+								<template #icon>
+									<SaveSharp />
+								</template>
+								{{ existing ? "Save" : "Create" }}
+							</PButton>
 						</template>
-						{{ existing ? "Save" : "Create" }}
-					</PButton>
+						Must set a plan name in Configuration to save
+					</PTooltip>
 					<PButton
 						v-if="existing"
 						:disabled="disabled"
@@ -563,72 +573,60 @@
 			<div class="row-4 md:col-span-3">
 				<!-- Toolbar -->
 				<div
-					class="flex flex-wrap grow @3xl:justify-between border-y border-white/10 gap-3 py-3 child:my-auto">
+					class="flex flex-wrap grow @3xl:justify-end border-y border-white/10 gap-3 py-3 child:my-auto">
 					<PButton
 						:type="
 							refShowTool === 'configuration'
 								? 'primary'
 								: 'secondary'
 						"
-						class="hidden @3xl:inline-block"
 						@click="toggleTool('configuration')">
+						<template #icon>
+							<SettingsSharp />
+						</template>
 						Configuration
 					</PButton>
-					<div class="flex flex-wrap grow @3xl:justify-end gap-3">
-						<PButton
-							:type="
-								refShowTool === 'configuration'
-									? 'primary'
-									: 'secondary'
-							"
-							class="@3xl:hidden"
-							@click="toggleTool('configuration')">
-							Configuration
-						</PButton>
-						<PButton
-							:type="
-								refShowTool === 'popr' ? 'primary' : 'secondary'
-							"
-							@click="toggleTool('popr')">
-							POPR
-						</PButton>
-						<PButton
-							:type="
-								refShowTool === 'visitation-frequency'
-									? 'primary'
-									: 'secondary'
-							"
-							@click="toggleTool('visitation-frequency')">
-							Visitation Frequency
-						</PButton>
-						<PButton
-							:type="
-								refShowTool === 'construction-cart'
-									? 'primary'
-									: 'secondary'
-							"
-							@click="toggleTool('construction-cart')">
-							Construction Cart
-						</PButton>
-						<PButton
-							:type="
-								refShowTool === 'supply-cart'
-									? 'primary'
-									: 'secondary'
-							"
-							@click="toggleTool('supply-cart')">
-							Supply Cart
-						</PButton>
-						<PButton
-							:type="
-								refShowTool === 'repair-analysis'
-									? 'primary'
-									: 'secondary'
-							"
-							@click="toggleTool('repair-analysis')">
-							Repair Analysis
-						</PButton>
-					</div>
+					<PButton
+						:type="refShowTool === 'popr' ? 'primary' : 'secondary'"
+						@click="toggleTool('popr')">
+						POPR
+					</PButton>
+					<PButton
+						:type="
+							refShowTool === 'visitation-frequency'
+								? 'primary'
+								: 'secondary'
+						"
+						@click="toggleTool('visitation-frequency')">
+						Visitation Frequency
+					</PButton>
+					<PButton
+						:type="
+							refShowTool === 'construction-cart'
+								? 'primary'
+								: 'secondary'
+						"
+						@click="toggleTool('construction-cart')">
+						Construction Cart
+					</PButton>
+					<PButton
+						:type="
+							refShowTool === 'supply-cart'
+								? 'primary'
+								: 'secondary'
+						"
+						@click="toggleTool('supply-cart')">
+						Supply Cart
+					</PButton>
+					<PButton
+						:type="
+							refShowTool === 'repair-analysis'
+								? 'primary'
+								: 'secondary'
+						"
+						@click="toggleTool('repair-analysis')">
+						Repair Analysis
+					</PButton>
 				</div>
 				<!-- Tool View -->
 				<div


### PR DESCRIPTION
- Moved configuration back into the main toolbar flow.
- Added gear icon to the configuration button
- Made save button visible on new plan creation, tweaked button group to allow tooltips
- Added building area to PlanProductionBuilding

<img width="1670" height="973" alt="image" src="https://github.com/user-attachments/assets/226d5d48-6bd6-4e9b-9a11-21fe3a2b6424" />
