### PR TITLE
Update default for Auto-Optimize Habs to false for existing plans

### DIFF
--- a/src/features/preferences/userDefaults.ts
+++ b/src/features/preferences/userDefaults.ts
@@ -22,6 +22,9 @@ export const preferenceDefaults: IPreferenceDefault = {
 	planDefaults: {
 		includeCM: false,
 		visitationMaterialExclusions: [],
-		autoOptimizeHabs: true,
+		// Auto-optimize habs is true by default for new plans, that value will
+		// be stored into the prefs on saving. But for existing plans, we want it
+		// to be false by default
+		autoOptimizeHabs: false,
 	},
 };


### PR DESCRIPTION
Setting the default value to false makes it so we won't automatically modify old plans when they are loaded. New plans will continue to default to `true` since the value is stored in PlanView and committed to the prefs upon plan creation.