### PR TITLE
fix(planning): add Core Module area (25) to profit per area calculation

### DIFF
--- a/src/features/planning/usePlanCalculation.ts
+++ b/src/features/planning/usePlanCalculation.ts
@@ -474,7 +474,7 @@ export async function usePlanCalculation(
 
 					// Recipe option Profit per Area
 					const optimalProductionData = optimalProduction.find((op) => op.ticker === br.BuildingTicker);
-					const areaPerBuilding: number = optimalProductionData ? optimalProductionData.total_area / optimalProductionData.amount : buildingData.AreaCost;
+					const areaPerBuilding: number = optimalProductionData ? (optimalProductionData.total_area + 25) / optimalProductionData.amount : buildingData.AreaCost + 25;
 
 					const profitPerArea = dailyRevenue / areaPerBuilding; 
 


### PR DESCRIPTION
Update the areaPerBuilding calculation to include the Core Module's
25 area cost when computing profit per area for production recipes.
This ensures the calculation accurately reflects the total area
required for optimal production setups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>