### PR TITLE
feat(plan): add "Save As" feature 

### DIFF
--- a/src/lib/analytics/useAnalytics.types.ts
+++ b/src/lib/analytics/useAnalytics.types.ts
@@ -30,6 +30,7 @@ export type ANALYTICS_EVENT_TYPE =
 	| "plan_leave_changed"
 	| "plan_reload"
 	| "plan_save"
+	| "plan_save_as"
 	| "plan_share_create"
 	| "plan_share_delete"
 	| "plan_shared_cloned"
@@ -82,6 +83,9 @@ export interface IAnalyticsEventProperties {
 		name: string | null;
 	};
 	plan_save: {
+		planetNaturalId: string;
+	};
+	plan_save_as: {
 		planetNaturalId: string;
 	};
 	plan_create: {

--- a/src/views/PlanView.vue
+++ b/src/views/PlanView.vue
@@ -441,9 +441,9 @@
 				planetNaturalId: planetData.PlanetNaturalId,
 			});
 
-			// Close modal and navigate to new plan (force reload to load fresh data)
+			// Close modal and open new plan in a new tab
 			refShowSaveAsModal.value = false;
-			window.location.href = `/plan/${planetData.PlanetNaturalId}/${newUuid}`;
+			window.open(`/plan/${planetData.PlanetNaturalId}/${newUuid}`, "_blank");
 			return;
 		}
 


### PR DESCRIPTION
  ## Summary
  Adds a "Save As" button that allows users to save the current plan (with any unsaved changes) as a new plan with a different name and optionally under a
  different empire.

  Closes #222

  ## Changes
  - New "Save As" button in the plan actions toolbar (only visible for existing plans)
  - Modal dialog with name input and empire selector
  - Pre-fills name with current plan name + " (Copy)"
  - Pre-fills empire with current selected empire
  - Navigates to the new plan after creation

  ## Screenshots

  ### Save As button location
<img width="320" height="43" alt="image" src="https://github.com/user-attachments/assets/8f2f0b39-b357-48ba-8213-a9c9be4016c8" />

  ### Save As modal
<img width="482" height="219" alt="image" src="https://github.com/user-attachments/assets/5bd7864e-9ad6-4d47-b48e-60b51dfc37e3" />