### PR TITLE
feat(ui): replaces n-table with XNDataTable for recipe options (fixes #334)

### DIFF
--- a/src/features/planning/components/PlanProductionRecipe.vue
+++ b/src/features/planning/components/PlanProductionRecipe.vue
@@ -166,8 +166,7 @@
 		<div
 			class="relative z-10"
 			:class="refShowRecipeOptions ? 'visible' : 'hidden'"
-			@click.stop
-		>
+			@click.stop>
 			<div class="absolute border border-pp-border bg-black! mt-1">
 				<XNDataTable
 					:data="localRecipeOptions"
@@ -182,25 +181,28 @@
 									recipe.RecipeId
 								),
 						})
-					"
-				>
+					">
 					<XNDataTableColumn key="Input" title="Input">
 						<template #render-cell="{ rowData }">
 							<div class="flex flex-row gap-1">
 								<span
-									v-if="rowData.RecipeId === localRecipeData.recipe.RecipeId"
-									class="w-2 h-2 bg-prunplanner animate-pulse rounded-full my-auto mr-1"
-								/>
+									v-if="
+										rowData.RecipeId ===
+										localRecipeData.recipe.RecipeId
+									"
+									class="w-2 h-2 bg-prunplanner animate-pulse rounded-full my-auto mr-1" />
 								<MaterialTile
 									v-for="material in rowData.Inputs"
 									:key="`${rowData.BuildingTicker}#INPUT#${material.Ticker}`"
 									:ticker="material.Ticker"
-									:amount="material.Amount"
-								/>
+									:amount="material.Amount" />
 							</div>
 						</template>
 					</XNDataTableColumn>
-					<XNDataTableColumn key="TimeMs" title="Time" sorter="default">
+					<XNDataTableColumn
+						key="TimeMs"
+						title="Time"
+						sorter="default">
 						<template #render-cell="{ rowData }">
 							{{ humanizeTimeMs(rowData.TimeMs) }}
 						</template>
@@ -216,7 +218,10 @@
 							</div>
 						</template>
 					</XNDataTableColumn>
-					<XNDataTableColumn key="dailyRevenue" title="$ / Day" sorter="default">
+					<XNDataTableColumn
+						key="dailyRevenue"
+						title="$ / Day"
+						sorter="default">
 						<template #render-cell="{ rowData }">
 							<span
 								:class="
@@ -228,7 +233,10 @@
 							</span>
 						</template>
 					</XNDataTableColumn>
-					<XNDataTableColumn key="profitPerArea" title="$ / Area" sorter="default">
+					<XNDataTableColumn
+						key="profitPerArea"
+						title="$ / Area"
+						sorter="default">
 						<template #render-cell="{ rowData }">
 							<span
 								:class="
@@ -248,31 +256,27 @@
 										? 'text-positive!'
 										: 'text-negative!'
 								">
-								{{ formatNumber(rowData.roi ) }} d
+								{{ formatNumber(rowData.roi) }} d
 							</span>
 						</template>
 					</XNDataTableColumn>
 				</XNDataTable>
 
-				<div
-					class="text-xs p-2! text-white/60!">
-					<strong>Revenue / Day</strong> is calculated by
-					taking the daily income generated from a recipe and
-					subtracting both the daily workforce cost (all
-					luxuries provided) and the daily building
-					degradation cost (1/180th of the construction cost).
-					The income from the recipe is based on the
-					difference between the input material costs and the
-					output material values. <strong>$ / Area</strong> is
-					the daily revenue divided by the area for one
-					production building and its proportionate share of
-					the area for a CM and habs required for an optimal
-					base of such buildings in Recipe ROI.
-					<strong>ROI (Payback)</strong> is the time required
-					for a continuously operating recipe to generate
-					enough revenue to offset the building's construction
-					cost. This considers daily degradation and workforce
-					costs as well.
+				<div class="text-xs p-2! text-white/60!">
+					<strong>Revenue / Day</strong> is calculated by taking the
+					daily income generated from a recipe and subtracting both
+					the daily workforce cost (all luxuries provided) and the
+					daily building degradation cost (1/180th of the construction
+					cost). The income from the recipe is based on the difference
+					between the input material costs and the output material
+					values. <strong>$ / Area</strong> is the daily revenue
+					divided by the area for one production building and its
+					proportionate share of the area for a CM and habs required
+					for an optimal base of such buildings in Recipe ROI.
+					<strong>ROI (Payback)</strong> is the time required for a
+					continuously operating recipe to generate enough revenue to
+					offset the building's construction cost. This considers
+					daily degradation and workforce costs as well.
 				</div>
 			</div>
 		</div>


### PR DESCRIPTION
Hi, @jplacht 

I often choose the most cost-effective recipe here. Other tables can be sorted, but only this one cannot be sorted, which puzzles me. So I tried to make some changes to achieve that.

I refer to your implementation elsewhere and use `XNDataTable` to replace original `n-table`.


| after | before |
|---|---|
|<img alt="image" src="https://github.com/user-attachments/assets/982ceae2-9d8f-43b8-95d6-4524a40ca002" />|<img alt="Image" src="https://github.com/user-attachments/assets/249d3682-d3bd-4a36-ac2e-961a2ed43738" />|

It mostly works well. Except the green active mark. Because I cannot pass class to table cell.
Although DataTable has a `cellProps` on [DataTableColumn](https://www.naiveui.com/en-US/os-theme/components/data-table#API), the [XNDataTable](https://github.com/fudiwei/x.naive-ui/blob/a15d32debf5ec51d6d3a1d6dc1a24348597335f5/src/data-table/DataTableColumn.tsx) as a wrapper doesn't pass all props.

We can pass columns props directly to solve this. But perhaps we can simply change the style to bypass it. I'd like to hear from you.




