### PR TITLE
Show warning when base has unplanned buildings

### DIFF
--- a/src/features/planning/components/tools/PlanConstructionCart.vue
+++ b/src/features/planning/components/tools/PlanConstructionCart.vue
@@ -32,7 +32,8 @@
 	import { IXITTransferMaterial } from "@/features/xit/xitAction.types";
 
 	// UI
-	import { PInputNumber, PSelect, PTable } from "@/ui";
+	import { PIcon, PInputNumber, PSelect, PTable, PTooltip } from "@/ui";
+	import { WarningAmberRound } from "@vicons/material";
 
 	const props = defineProps({
 		planetNaturalId: {
@@ -107,6 +108,15 @@
 	const buildingTicker = computed(() =>
 		props.constructionData.map((b) => b.ticker).sort()
 	);
+
+	const unplannedBuildings = computed(() => {
+		if (!constructedMap) return [];
+
+		const plannedSet = new Set(buildingTicker.value);
+		return Array.from(constructedMap.keys())
+			.filter(ticker => !plannedSet.has(ticker))
+			.sort((a, b) => a.localeCompare(b));
+	});
 
 	const totalMaterials = computed(() => {
 		const r: Record<string, number> = {};
@@ -259,7 +269,19 @@
 
 <template>
 	<div class="pb-3 flex flex-row justify-between child:my-auto">
-		<h2 class="text-white/80 font-bold text-lg">Construction Cart</h2>
+		<h2 class="text-white/80 font-bold text-lg inline-flex items-center">
+			Construction Cart
+					<PTooltip v-if="unplannedBuildings.length > 0">
+				<template #trigger>
+					<PIcon class="text-amber-400 ml-1 relative top-px">
+						<WarningAmberRound />
+					</PIcon>
+				</template>
+						Base has unplanned {{
+							unplannedBuildings.join("+")
+						}} — demolish for accurate area, habitation and materials.
+			</PTooltip>
+		</h2>
 		<div class="flex flex-row gap-x-3 child:my-auto!">
 			<XITTransferActionButton
 				:elements="xitTransferElements"

--- a/src/features/planning/components/tools/PlanConstructionCart.vue
+++ b/src/features/planning/components/tools/PlanConstructionCart.vue
@@ -14,6 +14,7 @@
 	import { usePrice } from "@/features/cx/usePrice";
 	import { useFIOStorage } from "@/features/fio/useFIOStorage";
 	import { useQuery } from "@/lib/query_cache/useQuery";
+	import { usePlanningStore } from "@/stores/planningStore";
 	import { useUserStore } from "@/stores/userStore";
 
 	// Components
@@ -21,6 +22,7 @@
 	import XITTransferActionButton from "@/features/xit/components/XITTransferActionButton.vue";
 
 	// Util
+	import { relativeFromDate } from "@/util/date";
 	import { clamp, formatAmount, formatNumber } from "@/util/numbers";
 
 	// Types & Interfaces
@@ -67,6 +69,8 @@
 
 	const { hasStorage, storageOptions, findStorageValueFromOptions } =
 		useFIOStorage();
+	const planningStore = usePlanningStore();
+	const fioUpdated = relativeFromDate(planningStore.fio_storage_timestamp ?? undefined);
 
 	// Get already constructed buildings
 	let constructedMap: Map<string, number> | null = null;
@@ -277,9 +281,10 @@
 						<WarningAmberRound />
 					</PIcon>
 				</template>
-						Base has unplanned {{
-							unplannedBuildings.join("+")
-						}} — demolish for accurate area, habitation and materials.
+						Base has unplanned {{ unplannedBuildings.join("+") }}
+						(FIO: {{ fioUpdated }})
+						<br>
+						Demolish to ensure area, habitation and materials are accurate
 			</PTooltip>
 		</h2>
 		<div class="flex flex-row gap-x-3 child:my-auto!">


### PR DESCRIPTION
<img width="922" height="356" alt="image" src="https://github.com/user-attachments/assets/7e4a63d9-6899-4e2a-9bb0-7e1d16b0a5a2" />

Context: When buildings exist on the base that aren't in the plan, e.g. pivoting a base.

Problem: Area and habitation will be inaccurate, and building materials will change when unplanned buildings are 
demolished.

Solution: Warn the user so they can decide what to do about it.