### PR TITLE
fix(market-live): Lowest Sell Price and Lowest Buy Price

### DIFF
--- a/src/features/market_live/fieldConfigs.ts
+++ b/src/features/market_live/fieldConfigs.ts
@@ -98,12 +98,12 @@ export const FieldConfigs: Partial<Record<keyof CXDataPoint, FieldConfig>> = {
 		operators: ["gt", "lt", "eq", "neq"],
 	},
 	lowest_sell_cost: {
-		label: "Lowest Buy Price",
+		label: "Best Ask Price",
 		type: "number",
 		operators: ["gt", "lt", "eq", "neq"],
 	},
 	highest_buy_cost: {
-		label: "Lowest Sell Price",
+		label: "Best Bid Price",
 		type: "number",
 		operators: ["gt", "lt", "eq", "neq"],
 	},


### PR DESCRIPTION
Theses strings are non sensical:
1. Lowest Buy Price could be true but if it were it would be meaningless, anyone could set any artificially low buy order for anything, yet this would have zero impact on the market.
2. The strings were swapped with the code name.