### PR TITLE
Fix construction cart habitation warning false positive

### DIFF
--- a/src/features/planning/components/tools/PlanConstructionCart.vue
+++ b/src/features/planning/components/tools/PlanConstructionCart.vue
@@ -354,7 +354,17 @@
 				<tr>
 					<th>Building</th>
 					<th v-if="constructedMap">Built</th>
-					<th>Amount</th>
+					<th class="inline-flex">
+						Amount
+							<PTooltip v-if="deficitWorkforceTypes.length > 0">
+							<template #trigger>
+								<PIcon class="text-amber-400 ml-1 relative top-px">
+									<WarningAmberRound />
+								</PIcon>
+							</template>
+							Insufficient habitation will reduce production efficiency
+						</PTooltip>
+					</th>
 					<th>Planned</th>
 					<th
 						v-for="mat in uniqueMaterials"

--- a/src/features/planning/components/tools/PlanConstructionCart.vue
+++ b/src/features/planning/components/tools/PlanConstructionCart.vue
@@ -356,7 +356,7 @@
 					<th v-if="constructedMap">Built</th>
 					<th class="inline-flex">
 						Amount
-							<PTooltip v-if="deficitWorkforceTypes.length > 0">
+						<PTooltip v-if="deficitWorkforceTypes.length > 0">
 							<template #trigger>
 								<PIcon class="text-amber-400 ml-1 relative top-px">
 									<WarningAmberRound />

--- a/src/features/planning/components/tools/PlanConstructionCart.vue
+++ b/src/features/planning/components/tools/PlanConstructionCart.vue
@@ -129,12 +129,18 @@
 			.sort((a, b) => a.localeCompare(b));
 	});
 
+	function getTotalBuildingAmount(ticker: string): number {
+		const builtAmount = constructedMap?.get(ticker) ?? 0;
+		const plannedAmount = localBuildingAmount.value[ticker] ?? 0;
+		return builtAmount + plannedAmount;
+	}
+
 	const deficitWorkforceTypes = computed(() => {
 		return (workforceTypeNames as WORKFORCE_TYPE[]).filter(
 			(workforceType) =>
 				buildingTicker.value.reduce((sum, ticker) => {
 					const building = buildingsMap.value[ticker];
-					const amount = localBuildingAmount.value[ticker] ?? 0;
+					const amount = getTotalBuildingAmount(ticker);
 					const field = `${workforceType}s` as keyof NonNullable<
 						IBuilding["habitations"]
 					>;
@@ -142,7 +148,7 @@
 				}, 0) >
 				buildingTicker.value.reduce((sum, ticker) => {
 					const building = buildingsMap.value[ticker];
-					const amount = localBuildingAmount.value[ticker] ?? 0;
+					const amount = getTotalBuildingAmount(ticker);
 					const field = `${workforceType}s` as keyof NonNullable<
 						IBuilding["habitations"]
 					>;


### PR DESCRIPTION
https://github.com/PRUNplanner/frontend/pull/390 can false positive because it only looks at Amount, not Amount + Built. Example:

<img width="641" height="475" alt="image" src="https://github.com/user-attachments/assets/a103cc5e-8631-4fee-8ff3-f44ae47945c9" />

This PR fixes the calculations and adds a tooltip so users know what's gone wrong:

<img width="449" height="203" alt="image" src="https://github.com/user-attachments/assets/6be1ea0f-9075-4632-a935-ffad399803d3" />
