### PR TITLE
Fix plan page niggles

### DIFF
--- a/src/features/planning/components/PlanProductionBuilding.vue
+++ b/src/features/planning/components/PlanProductionBuilding.vue
@@ -126,8 +126,8 @@
 			</PButton>
 		</div>
 		<div
-			class="col-span-12 xl:col-span-6 flex justify-end items-center gap-6 text-white/80">
-			<div class="flex flex-col items-end">
+			class="col-span-12 xl:col-span-6 grid grid-cols-12 items-center gap-x-3 text-white/80">
+			<div class="col-span-3 flex flex-col items-end min-w-0 text-right">
 				<span
 					class="text-[10px] text-white/50 uppercase tracking-wider">
 					Expertise
@@ -141,11 +141,11 @@
 					>
 				</span>
 			</div>
-			<div class="flex flex-col items-end">
+			<div class="col-span-2 flex flex-col items-end text-right">
 				<span class="text-[10px] text-white/50 uppercase tracking-wide">
 					Efficiency
 				</span>
-				<span class="text-xs font-mono font-bold">
+				<span class="text-xs font-mono font-bold whitespace-nowrap">
 					<PTooltip>
 						<template #trigger>
 							<div class="flex gap-x-1 hover:cursor-help">
@@ -171,12 +171,12 @@
 					</PTooltip>
 				</span>
 			</div>
-			<div class="flex flex-col items-end">
+			<div class="col-span-3 flex flex-col items-end text-right">
 				<span class="text-[10px] text-white/50 uppercase tracking-wide">
 					Revenue
 				</span>
 				<span
-					class="text-xs font-mono font-bold text-positive"
+					class="text-xs font-mono font-bold text-positive whitespace-nowrap"
 					:class="
 						localBuildingData.dailyRevenue >= 0
 							? 'text-positive!'
@@ -186,24 +186,24 @@
 					<span class="font-light text-white/50">ȼ</span>
 				</span>
 			</div>
-			<div class="flex flex-col items-end">
+			<div class="col-span-1 flex flex-col items-end text-right">
 				<span class="text-[10px] text-white/50 uppercase tracking-wide">
 					Area
 				</span>
-				<span class="text-xs font-mono font-bold">
+				<span class="text-xs font-mono font-bold whitespace-nowrap">
 					{{ localBuildingData.areaUsed }}
 				</span>
 			</div>
-			<div class="flex flex-col items-end">
+			<div class="col-span-2 flex flex-col items-end text-right">
 				<span class="text-[10px] text-white/50 uppercase tracking-wide">
 					Construction
 				</span>
-				<span class="text-xs font-mono font-bold">
+				<span class="text-xs font-mono font-bold whitespace-nowrap">
 					{{ formatNumber(localBuildingData.constructionCost * -1) }}
 					<span class="font-light text-white/50">ȼ</span>
 				</span>
 			</div>
-			<div>
+			<div class="col-span-1 flex justify-end">
 				<PButton
 					:disabled="disabled"
 					size="sm"

--- a/src/ui/components/PSelect.vue
+++ b/src/ui/components/PSelect.vue
@@ -220,7 +220,7 @@
 				</div>
 				<div
 					v-else
-					class="grow child:child:bg-transparent! py-0.5"
+					class="grow child:child:bg-transparent!"
 					@click.stop="ensureOpened">
 					<PInput v-model:value="searchString" placeholder="Search" />
 				</div>

--- a/src/ui/components/PSelect.vue
+++ b/src/ui/components/PSelect.vue
@@ -42,7 +42,6 @@
 	const triggerRef = ref<HTMLElement | null>(null);
 	const dropdownRef = ref<HTMLElement | null>(null);
 	const componentId = `select-${Math.random().toString(36).substring(2, 9)}`;
-	const dropdownPosition = ref({ top: "0px", left: "0px", width: "100px" });
 
 	const displayValue: ComputedRef<string> = computed(() => {
 		const allOptions: PSelectOption[] = [];
@@ -247,8 +246,7 @@
 			<div
 				v-if="open"
 				ref="dropdownRef"
-				class="z-5000 p-1 bg-gray-900 text-white rounded-sm shadow-lg max-h-75 overflow-auto"
-				:style="dropdownPosition">
+				class="z-5000 p-1 bg-gray-900 text-white rounded-sm shadow-lg max-h-75 overflow-auto">
 				<div
 					class="w-full flex flex-col bg-gray-900 child:py-1 child:px-2 child:hover:bg-gray-800 rounded-b-sm">
 					<PSelectElement

--- a/src/ui/components/PSelectMultiple.vue
+++ b/src/ui/components/PSelectMultiple.vue
@@ -46,7 +46,6 @@
 	const dropdownRef = ref<HTMLElement | null>(null);
 	const searchInputRef = ref<{ focus: () => void } | null>(null);
 	const componentId = `select-${Math.random().toString(36).substring(2, 9)}`;
-	const dropdownPosition = ref({ top: "0px", left: "0px", width: "100px" });
 
 	/** Selected items as { value, label } for correct remove by value */
 	const selectedEntries: ComputedRef<
@@ -275,8 +274,7 @@
 			<div
 				v-if="open"
 				ref="dropdownRef"
-				class="z-5000 p-1 bg-gray-900 text-white rounded-sm shadow-lg max-h-75 overflow-auto"
-				:style="dropdownPosition">
+				class="z-5000 p-1 bg-gray-900 text-white rounded-sm shadow-lg max-h-75 overflow-auto">
 				<div
 					class="w-full flex flex-col bg-gray-900 child:py-1 child:px-2 child:hover:bg-gray-800 rounded-b-sm">
 					<PInput


### PR DESCRIPTION
A few small annoyances that were easy to patch:
1. Fixed selects changing height on focus (building selector, supply cart supply, etc.)
2. Fixed building list attachment when a toolbar tab is open
3. Fixed production table alignment