### PR TITLE
Fix recipe selector ROI column sorting

### DIFF
--- a/src/features/planning/components/PlanProductionRecipe.vue
+++ b/src/features/planning/components/PlanProductionRecipe.vue
@@ -105,6 +105,13 @@
 	);
 
 	const cogmWithCX = computed(() => !!props.cxUuid);
+
+	function roiSorter(
+		row1: Record<string, unknown>,
+		row2: Record<string, unknown>
+	): number {
+		return (row1.dailyRevenue as number) - (row2.dailyRevenue as number);
+	}
 </script>
 
 <template>
@@ -255,7 +262,7 @@
 						</span>
 					</template>
 				</XNDataTableColumn>
-				<XNDataTableColumn key="roi" title="ROI" sorter="default">
+				<XNDataTableColumn key="roi" title="ROI" :sorter="roiSorter">
 					<template #render-cell="{ rowData }">
 						<span
 							:class="

--- a/src/features/planning/components/PlanProductionRecipe.vue
+++ b/src/features/planning/components/PlanProductionRecipe.vue
@@ -270,7 +270,7 @@
 									? 'text-positive!'
 									: 'text-negative!'
 							">
-							{{ formatNumber(rowData.roi) }} d
+							{{ rowData.roi < 0 ? "—" : formatNumber(rowData.roi) + " d" }}
 						</span>
 					</template>
 				</XNDataTableColumn>


### PR DESCRIPTION
# Problem

Lower negative revenue options have an ROI closer to zero; however you sort, the best option is in the middle:

<img width="700" height="510" alt="image" src="https://github.com/user-attachments/assets/ff533dae-eaae-44f4-bb9d-f381597779d8" />

# Solution

ROI actually sorts by revenue per area and negative values are hidden to prevent worse options looking better because they're closer to zero:

<img width="700" height="510" alt="image" src="https://github.com/user-attachments/assets/73b50c4f-0410-49db-b33b-4a68dfa29f38" />