### PR TITLE
Fix storage filling calculations

### DIFF
--- a/src/features/planning/components/tools/PlanVisitationFrequency.vue
+++ b/src/features/planning/components/tools/PlanVisitationFrequency.vue
@@ -90,8 +90,8 @@
 			(sum, e) => sum + (e.delta > 0 ? e.totalVolume : 0),
 			0
 		);
-		const dailyWeightTotal: number = dailyWeightImport + dailyWeightExport;
-		const dailyVolumeTotal: number = dailyVolumeImport + dailyVolumeExport;
+		const dailyWeightTotal: number = Math.max(dailyWeightImport, dailyWeightExport);
+		const dailyVolumeTotal: number = Math.max(dailyVolumeImport, dailyVolumeExport);
 
 		return {
 			storageFilled: Math.max(

--- a/src/features/planning/usePlanCalculation.ts
+++ b/src/features/planning/usePlanCalculation.ts
@@ -919,8 +919,8 @@ export async function usePlanCalculation(
 			(sum, e) => sum + (e.delta > 0 ? e.totalVolume : 0),
 			0
 		);
-		const dailyWeightTotal: number = dailyWeightImport + dailyWeightExport;
-		const dailyVolumeTotal: number = dailyVolumeImport + dailyVolumeExport;
+		const dailyWeightTotal: number = Math.max(dailyWeightImport, dailyWeightExport);
+		const dailyVolumeTotal: number = Math.max(dailyVolumeImport, dailyVolumeExport);
 
 		return {
 			storageFilled: Math.max(

--- a/src/tests/features/planning/usePlanCalculation.test.ts
+++ b/src/tests/features/planning/usePlanCalculation.test.ts
@@ -141,7 +141,7 @@ describe("usePlanCalculation", async () => {
 
 		const result = await calculate();
 
-		expect(visitationData.value.storageFilled).toBe(22.342256698594255);
+		expect(visitationData.value.storageFilled).toBe(26.462529131522697);
 	});
 
 	it("validate existing and saveable", async () => {


### PR DESCRIPTION
Sorry if I misunderstand, but I'm looking at [this plan](https://prunplanner.org/shared/3b26959f-f281-41f6-bc12-343957c67e36)

<img width="228" height="211" alt="Screenshot 2026-05-18 at 9 52 09 PM" src="https://github.com/user-attachments/assets/0bd2b4ab-5726-48b9-a6c0-e42fda4d22d0" />

It has 6500/6500 storage, so I can bring 30 days of input mats which will completely pack the base, then I can wait 30 days and it will be only 1/3 full and everything is fine. The Filled row implies to me it would take 22.31 days. 

I think the 3rd row should be "which is the bottleneck?" and the filled row should be "how many days can this base go between visitations?" I'm not super convinced the 3rd row is useful to show and Filled isn't the right word for it (maybe "Storage Maximum") , but I'll leave those decisions up to you and also because of localization. 