### PR TITLE
Don't auto-optimize shared plans

### DIFF
--- a/src/views/PlanView.vue
+++ b/src/views/PlanView.vue
@@ -175,7 +175,7 @@
 	// Plan Preferences
 	const planPrefs = computed<ReturnType<typeof usePlanPreferences> | null>(
 		() => {
-			return !props.disabled && props.planData.uuid !== undefined
+			return props.planData.uuid !== undefined
 				? usePlanPreferences(props.planData.uuid)
 				: null;
 		}


### PR DESCRIPTION
When I view https://prunplanner.org/shared/3b26959f-f281-41f6-bc12-343957c67e36 unlogged, I see 503/500 area used which isn't what my saved plan has.

This is because the auto-optimized habs checkbox is set. I think it's unnecessary to check props.disabled in PlanView.vue for the planPerfs variable because it's only used for the binding of the value of the auto-optimized hab's checkbox. I think we want it checked for unsaved plans otherwise it uses the plan's settings. Before it was set to true for unsaved plans and shared plans (disabled == shared plans if you trace it through to usePlanningDataLoader)