### PR TITLE
Add missing handleResetModified()

### DIFF
--- a/src/views/PlanView.vue
+++ b/src/views/PlanView.vue
@@ -449,6 +449,7 @@
 		await reloadExistingPlan(refPlanData.value.uuid).then(
 			(result: IPlan) => (refPlanData.value = result)
 		);
+		handleResetModified();
 
 		trackEvent("plan_reload", {
 			planetNaturalId: planetData.planet_natural_id,


### PR DESCRIPTION
One line quick fix for:

- Steps: Edit plan, click Reload, changes discarded
- Before: Save button stays red
- After: Save button resets