### PR TITLE
Construction cart improvements

### DIFF
--- a/src/features/planning/components/tools/PlanConstructionCart.vue
+++ b/src/features/planning/components/tools/PlanConstructionCart.vue
@@ -282,6 +282,14 @@
 			}))
 		);
 
+	const xitTransferElementsNeed: ComputedRef<IXITTransferMaterial[]> =
+		computed(() =>
+			totalMaterialsSorted.value.map((e) => ({
+				ticker: e.ticker,
+				value: e.total,
+			}))
+		);
+
 	const refSelectedStorage: Ref<string | undefined> = ref(
 		hasStorage.value
 			? storageOptions.value.filter(
@@ -317,7 +325,7 @@
 	});
 
 	watch(
-		() => xitTransferElementsOverview.value,
+		() => xitTransferElementsNeed.value,
 		async (overview) => {
 			overviewTotalInformation.value = await calculateTotal(overview);
 		},
@@ -532,7 +540,7 @@
 							class="w-62.5!" />
 					</template>
 					<XITTransferActionButton
-						:elements="xitTransferElementsOverview"
+						:elements="xitTransferElementsNeed"
 						transfer-name="Construct"
 						:drawer-width="400" />
 				</div>

--- a/src/ui/components/PInputNumber.vue
+++ b/src/ui/components/PInputNumber.vue
@@ -67,17 +67,14 @@
 
 	function canChange(e: number): boolean {
 		if (disabled) return false;
-		if (value.value === null || value.value === undefined) return true;
-
-		if (value.value + e >= min && value.value + e <= max) return true;
+		const currentValue: number = value.value ?? 0;
+		if (currentValue + e >= min && currentValue + e <= max) return true;
 		return false;
 	}
 
 	function change(e: number) {
 		if (canChange(e)) {
-			if (value.value === null || value.value === undefined)
-				value.value = 0;
-			value.value += e;
+			value.value = (value.value ?? 0) + e;
 		}
 	}
 </script>


### PR DESCRIPTION
Material table footer (cost/weight/volume) and XIT button use Need column, instead of just duplicating the Construction Cart table.

Also fixed PInputNumber bug where +/- buttons were enabled for empty values, causing NaN and broken calculations.

<img width="662" height="578" alt="Untitled" src="https://github.com/user-attachments/assets/528a427a-a58f-4ead-b9c4-ff1d7ca42830" />
