### PR TITLE
Fix test errors and date/time loading from epoch

### DIFF
--- a/src/util/date.ts
+++ b/src/util/date.ts
@@ -43,7 +43,7 @@ export function dateStringFromEpoch(
 	value: number,
 	dateFormat = "YYYY-MM-DD"
 ): string {
-	return dayjs(value).format(dateFormat);
+	return dayjs.utc(value).format(dateFormat);
 }
 
 /**

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -21,6 +21,7 @@ export default defineConfig({
 			"**/{karma,rollup,webpack,vite,vitest,jest,ava,babel,nyc,cypress,tsup,build}.config.*",
 			"**/cypress/**",
 			"**/.{idea,git,cache,output,temp}/**",
+			"**/*.md",
 		],
 		environment: "jsdom",
 		coverage: {
@@ -45,6 +46,7 @@ export default defineConfig({
 				"**/*.d.ts",
 				"src/router/**",
 				"src/lib/analytics/**",
+				"**/*.md",
 			],
 			reportOnFailure: true,
 		},


### PR DESCRIPTION
Two test fixes:

1. Exclude .md files from test run and coverage, fixes parse errors on `pnpm run test`.
2. On my local machine (UTC-4), the date/time unit test fails due to epoch being processed as local time instead of UTC.

```
⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯ Failed Tests 1 ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯

 FAIL  src/tests/util/date.test.ts > Util: date > dateStringFromEpoch > validates standard formatting, custom patterns, and edge cases
AssertionError: expected '1969-12-31' to be '1970-01-01' // Object.is equality

Expected: "1970-01-01"
Received: "1969-12-31"

 ❯ src/tests/util/date.test.ts:103:35
    101|
    102|    // Unix Epoch start
    103|    expect(dateStringFromEpoch(0)).toBe("1970-01-01");
       |                                   ^
    104|
    105|    // Negative epoch (pre-1970)

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[1/1]⎯
```

Instead of changing the test, I have updated the dateStringFromEpoch to load from UTC instead of local. This will cause the charts to shift their visible X axis labels by 1 day.