### PR TITLE
Remember supply cart days

### DIFF
--- a/src/features/api/schemas/user.schemas.ts
+++ b/src/features/api/schemas/user.schemas.ts
@@ -136,6 +136,7 @@ export const UserPreferenceSchema: z.ZodType<IPreference> = z.object({
 	burnDaysYellow: z.number(),
 	burnResupplyDays: z.number(),
 	burnOrigin: z.string(),
+	supplyCartDays: z.number(),
 	layoutNavigationStyle: z.enum(["full", "collapsed"]),
 	planOverrides: z.record(
 		z.string(),

--- a/src/features/planning/components/tools/PlanSupplyCart.vue
+++ b/src/features/planning/components/tools/PlanSupplyCart.vue
@@ -17,6 +17,7 @@
 
 	// Composables
 	import { useFIOStorage } from "@/features/fio/useFIOStorage";
+	import { usePreferences } from "@/features/preferences/usePreferences";
 
 	// Types & Interfaces
 	import { IMaterialIO } from "@/features/planning/usePlanCalculation.types";
@@ -72,8 +73,7 @@
 
 	const { hasStorage, storageOptions, findStorageValueFromOptions } =
 		useFIOStorage();
-
-	const refStockRequirement: Ref<number> = ref(20);
+	const { supplyCartDays: refStockRequirement } = usePreferences();
 	const refSelectedStorage: Ref<string | undefined> = ref(
 		hasStorage.value
 			? storageOptions.value.filter(

--- a/src/features/preferences/usePreferences.ts
+++ b/src/features/preferences/usePreferences.ts
@@ -92,6 +92,12 @@ export function usePreferences() {
 		set: (v) => userStore.setPreference("burnOrigin", v),
 	});
 
+	const supplyCartDays: WritableComputedRef<number, number> =
+		computed({
+			get: () => userStore.preferences.supplyCartDays ?? 20,
+			set: (v) => userStore.setPreference("supplyCartDays", v),
+		});
+
 	const planSettings: ComputedRef<
 		Record<string, Partial<IPreferencePerPlan>>
 	> = computed(() => {
@@ -234,6 +240,7 @@ export function usePreferences() {
 		burnDaysYellow,
 		burnResupplyDays,
 		burnOrigin,
+		supplyCartDays,
 		planSettings,
 		planSettingsOverview,
 		layoutNavigationStyle,

--- a/src/features/preferences/userDefaults.ts
+++ b/src/features/preferences/userDefaults.ts
@@ -17,6 +17,7 @@ export const preferenceDefaults: IPreferenceDefault = {
 	burnDaysYellow: 10,
 	burnResupplyDays: 20,
 	burnOrigin: "Configure on Execution",
+	supplyCartDays: 20,
 	layoutNavigationStyle: "full",
 
 	planOverrides: {},

--- a/src/features/preferences/userPreferences.types.ts
+++ b/src/features/preferences/userPreferences.types.ts
@@ -15,6 +15,7 @@ export interface IPreference {
 	burnDaysYellow: number;
 	burnResupplyDays: number;
 	burnOrigin: string;
+	supplyCartDays: number;
 	layoutNavigationStyle: "full" | "collapsed";
 
 	// seeding per plan defaults


### PR DESCRIPTION
Use pinia/localstorage to persist `Plan > Supply Card > Stock Duration (days)` so you don't have to change it every time